### PR TITLE
Support for Additional Databases in MongoDbEnt

### DIFF
--- a/service/util/service_type.go
+++ b/service/util/service_type.go
@@ -16,7 +16,7 @@ func ParseServiceType(serviceType string) ServiceType {
 		return Postgres
 	case "mysql", "mariadb", "mariadbent", "pxc", "galera", "mysql-database":
 		return MySQL
-	case "mongo", "mongodb", "mongodb-2", "mongodbent", "mangodb":
+	case "mongo", "mongodb", "mongodb-2", "mongodbent", "mongodbent-database", "mangodb":
 		return MongoDB
 	case "redis", "redis-2", "redisent", "redis-enterprise", "redis-ha":
 		return Redis


### PR DESCRIPTION
The service type for the additional DB on the same service for mongoDB ent has a different value.
Adding it to the list of already existing mongo dbs.