### PR TITLE
Remove use and create from backups for mysql single db backups

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -23,7 +23,7 @@ applications:
 
   # ### push either as docker image
   docker:
-    image: jamesclonk/backman:1.15.0 # choose version from https://hub.docker.com/r/jamesclonk/backman/tags, or 'latest'
+    image: jamesclonk/backman:1.16.0 # choose version from https://hub.docker.com/r/jamesclonk/backman/tags, or 'latest'
   # ### or as buildpack/src
   # buildpacks:
   # - https://github.com/cloudfoundry/apt-buildpack

--- a/service/mysql/backup.go
+++ b/service/mysql/backup.go
@@ -48,6 +48,7 @@ func Backup(ctx context.Context, s3 *s3.Client, service util.Service, binding *c
 	command = append(command, "-u")
 	command = append(command, credentials.Username)
 	if len(credentials.Database) > 0 {
+		command = append(command, "--no-create-db")
 		command = append(command, credentials.Database)
 	} else {
 		command = append(command, "--all-databases")

--- a/service/mysql/backup.go
+++ b/service/mysql/backup.go
@@ -48,7 +48,6 @@ func Backup(ctx context.Context, s3 *s3.Client, service util.Service, binding *c
 	command = append(command, "-u")
 	command = append(command, credentials.Username)
 	if len(credentials.Database) > 0 {
-		command = append(command, "--databases")
 		command = append(command, credentials.Database)
 	} else {
 		command = append(command, "--all-databases")


### PR DESCRIPTION
Adding the --no-create-db and removing the --databases in order to remove the USE and CREATE statements inside the mysql backup as the database name is supplied by the restore command