### PR TITLE
Add backwards compatibility for previous encrypted backups

### DIFF
--- a/s3/encryption.go
+++ b/s3/encryption.go
@@ -18,9 +18,11 @@ import (
 // | Magic | Version | Encryption | KDF |
 type header [4]byte
 
-func (h header) Version() byte    {return h[1]}
-func (h header) Encryption() byte {return h[2]}
-func (h header) KDF() byte        {return h[3]}
+func (h header) Version() byte    { return h[1] }
+func (h header) Encryption() byte { return h[2] }
+func (h header) KDF() byte        { return h[3] }
+
+// Validate validates the headers content
 func (h header) Validate() error {
 	if h[0] != magicByte {
 		return fmt.Errorf("wrong magic bytes, expected %v, got %v", magicByte, h[0])
@@ -38,7 +40,7 @@ func (h header) Validate() error {
 		return fmt.Errorf("unexpected encryption: %v", h.Encryption())
 	}
 	switch h.KDF() {
-	case KDFScrypt:
+	case kdfScrypt:
 		break
 	default:
 		return fmt.Errorf("unexpected KDF %v", h.KDF())
@@ -46,7 +48,8 @@ func (h header) Validate() error {
 	return nil
 }
 
-func NewHeader(encryption, kdf byte) header {
+// newHeader creates a new header for the given encryption and kdf
+func newHeader(encryption, kdf byte) header {
 	return header{magicByte, versionV10, encryption, kdf}
 }
 
@@ -60,17 +63,19 @@ const (
 )
 
 const (
-	KDFUnknown byte = iota
-	KDFOldMD5
-	KDFOldScryptHKDF
-	KDFScrypt  = 0x10 // N=32768, r=8 and p=1.
+	kdfUnknown byte = iota
+	kdfOldMD5       // needed for backwards compatibility
+	kdfOldScryptHKDF // needed for backwards compatibility
+	kdfScrypt = 0x10 // N=32768, r=8 and p=1.
 )
 
+// getKey returns a key derived from the given masterKey, object and header
+// when the kdf is unknown or one of the old methods, it needs to peek in the reader and thus reset it before returning
 func getKey(masterKey string, object string, hdr header, reader io.ReadSeeker) ([]byte, error) {
 	switch hdr.KDF() {
-	case KDFScrypt:
+	case kdfScrypt:
 		return generateKeyScrypt(masterKey, object)
-	case KDFUnknown, KDFOldMD5, KDFOldScryptHKDF:
+	case kdfUnknown, kdfOldMD5, kdfOldScryptHKDF:
 		// this is only for backwards compatibility
 		key := generateKeyPre123(masterKey)
 		if err := tryOldDecryption(key, reader); err != nil {
@@ -85,18 +90,20 @@ func getKey(masterKey string, object string, hdr header, reader io.ReadSeeker) (
 	return nil, fmt.Errorf("no valid kdf: %v", hdr.KDF())
 }
 
+// generateKey derives a key from the given masterKey, object and header
 func generateKey(masterKey string, object string, hdr header) ([]byte, error) {
 	switch hdr.KDF() {
-	case KDFScrypt:
+	case kdfScrypt:
 		return generateKeyScrypt(masterKey, object)
-	case KDFOldMD5:
+	case kdfOldMD5:
 		return generateKeyPre123(masterKey), nil
-	case KDFOldScryptHKDF:
+	case kdfOldScryptHKDF:
 		return generateKey124(masterKey, object), nil
 	}
 	return nil, fmt.Errorf("no valid kdf: %v", hdr.KDF())
 }
 
+// generateKeyScrypt derives the key from the given masterKey and object with the scrypt KDF
 func generateKeyScrypt(masterKey, object string) ([]byte, error) {
 	nonce := filepath.Base(object)
 	hasher := sha256.New()
@@ -110,35 +117,42 @@ func generateKeyScrypt(masterKey, object string) ([]byte, error) {
 	return key, nil
 }
 
-func generateKeyPre123(password string) []byte {
+// generateKeyPre123 derives the key via md5 hashing masterKey
+// This is not secure and mainly kept for being able to decrypt old backups
+func generateKeyPre123(masterKey string) []byte {
 	hasher := md5.New()
-	hasher.Write([]byte(password))
+	hasher.Write([]byte(masterKey))
 	return []byte(hex.EncodeToString(hasher.Sum(nil)))
 }
 
-func generateKey124(password, object string) []byte {
+// generateKey124 derives the key from the given masterKey and object via scrypt and hkdf and using the hash(mk,o) as salt
+// This is overly complicated without providing a real improvement in security
+// It is mainly kept for being able to decrypt old backups
+func generateKey124(masterKey, object string) []byte {
 	nonce := filepath.Base(object)
 
 	hasher := sha256.New()
-	if n, err := hasher.Write([]byte(fmt.Sprintf("%s%s", password, nonce))); err != nil || n <= 0 {
+	if n, err := hasher.Write([]byte(fmt.Sprintf("%s%s", masterKey, nonce))); err != nil || n <= 0 {
 		log.Fatalf("could not get salt: %v", err)
 	}
 	salt := hex.EncodeToString(hasher.Sum(nil))
 
-	masterKey, err := scrypt.Key([]byte(password), []byte(salt), 32768, 8, 1, 32)
+	intKey, err := scrypt.Key([]byte(masterKey), []byte(salt), 32768, 8, 1, 32)
 	if err != nil {
 		log.Fatalf("could not get master key: %v", err)
 	}
 
 	// derive encryption key, using filename as nonce (filenames contain timestamps and are unique per backman deployment)
 	var key [32]byte
-	kdf := hkdf.New(sha256.New, []byte(masterKey), []byte(nonce)[:], nil)
+	kdf := hkdf.New(sha256.New, intKey, []byte(nonce)[:], nil)
 	if _, err := io.ReadFull(kdf, key[:]); err != nil {
 		log.Fatalf("failed to derive encryption key: %v", err)
 	}
 	return key[:]
 }
 
+// tryOldDecryption peeks in the given reader and tries to decrypt with the given key
+// This is used to decrypt backups which don't have a header and therefore have no information about the used kdf/encryption
 func tryOldDecryption(key []byte, reader io.ReadSeeker) error {
 	// reset reader to read from beginning
 	if _, err := reader.Seek(0, 0); err != nil {
@@ -148,8 +162,8 @@ func tryOldDecryption(key []byte, reader io.ReadSeeker) error {
 	if err != nil {
 		return err
 	}
-	peak := make([]byte, 8)
-	if _, err := decrypter.Read(peak); err != nil {
+	peek := make([]byte, 8)
+	if _, err := decrypter.Read(peek); err != nil {
 		return err
 	}
 	// reset again
@@ -157,4 +171,17 @@ func tryOldDecryption(key []byte, reader io.ReadSeeker) error {
 		return err
 	}
 	return nil
+}
+
+// readHeader reads and validates the header from the given reader
+func readHeader(reader io.Reader) (header, error) {
+	hdr := header{}
+	if _, err := reader.Read(hdr[:]); err != nil {
+		return hdr, fmt.Errorf("couldn't read header: %v", err)
+	}
+	if err := hdr.Validate(); err != nil {
+		// try old method
+		hdr = newHeader(sio.AES_256_GCM, kdfUnknown)
+	}
+	return hdr, nil
 }

--- a/s3/encryption_test.go
+++ b/s3/encryption_test.go
@@ -3,69 +3,41 @@ package s3
 import (
 	"bytes"
 	"github.com/minio/sio"
-	"reflect"
 	"testing"
 )
 
-func Test_getKey(t *testing.T) {
-	type args struct {
-		masterKey string
-		object    string
-		hdr       header
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    []byte
-		wantErr bool
-	}{
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := generateKey(tt.args.masterKey, tt.args.object, tt.args.hdr)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("getKey() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getKey() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestEncryptionDecryption(t *testing.T) {
-	tests := []struct{
-		name string
-		masterkey string
-		object string
-		hdr header
+	tests := []struct {
+		name        string
+		masterkey   string
+		object      string
+		hdr         header
 		writeHeader bool
 	}{
 		{
-			name: "old md5 kdf",
+			name:      "old md5 kdf",
 			masterkey: "test",
-			object: "some-bucket/my-file.ext",
-			hdr: NewHeader(sio.AES_256_GCM, KDFOldMD5),
+			object:    "some-bucket/my-file.ext",
+			hdr:       newHeader(sio.AES_256_GCM, kdfOldMD5),
 		},
 		{
-			name: "old scrypt kdf",
+			name:      "old scrypt kdf",
 			masterkey: "test",
-			object: "some-bucket/my-file.ext",
-			hdr: NewHeader(sio.AES_256_GCM, KDFOldScryptHKDF),
+			object:    "some-bucket/my-file.ext",
+			hdr:       newHeader(sio.AES_256_GCM, kdfOldScryptHKDF),
 		},
 		{
-			name: "new scrypt kdf",
-			masterkey: "test",
-			object: "some-bucket/my-file.ext",
-			hdr: NewHeader(sio.AES_256_GCM, KDFScrypt),
+			name:        "new scrypt kdf",
+			masterkey:   "test",
+			object:      "some-bucket/my-file.ext",
+			hdr:         newHeader(sio.AES_256_GCM, kdfScrypt),
 			writeHeader: true,
 		},
 	}
 
-	for _, tt := range tests{
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var testdata= []byte("testdata")
+			var testdata = []byte("testdata")
 			var encBuf = &bytes.Buffer{}
 			enckey, err := generateKey(tt.masterkey, tt.object, tt.hdr)
 			if err != nil {

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -49,7 +49,7 @@ func (s *Client) UploadWithContext(ctx context.Context, object string, reader io
 	var err error
 	uploadReader := reader
 	if len(config.Get().S3.EncryptionKey) != 0 {
-		hdr := NewHeader(sio.AES_256_GCM, KDFScrypt)
+		hdr := newHeader(sio.AES_256_GCM, kdfScrypt)
 		if err := hdr.Validate(); err != nil {
 			return fmt.Errorf("header is invalid: %v", err)
 		}
@@ -110,18 +110,6 @@ func (s *Client) DownloadWithContext(ctx context.Context, object string) (io.Rea
 		return ioutil.NopCloser(decrypted), nil
 	}
 	return reader, nil
-}
-
-func readHeader(reader io.Reader) (header, error) {
-	hdr := header{}
-	if _, err := reader.Read(hdr[:]); err != nil {
-		return hdr, fmt.Errorf("couldn't read header: %v", err)
-	}
-	if err := hdr.Validate(); err != nil {
-		// try old method
-		hdr = NewHeader(sio.AES_256_GCM, KDFUnknown)
-	}
-	return hdr, nil
 }
 
 func (s *Client) Delete(object string) error {


### PR DESCRIPTION
The newly created backups contain a header identifying the used kdf (and encryption).
For reading old backups which don't contain this header the old method is attempted.
Further the kdf was simplified to just use scrypt and not scrypt+hkdf.