### PR TITLE
Custom options for creating and restoring MySQL backups

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,9 +43,11 @@ type ServiceConfig struct {
 		Days  int
 		Files int
 	}
-	DisableColumnStatistics bool   `json:"disable_column_statistics"`
-	ForceImport             bool   `json:"force_import"`
-	LocalBackupPath         string `json:"local_backup_path"`
+	DisableColumnStatistics bool     `json:"disable_column_statistics"`
+	ForceImport             bool     `json:"force_import"`
+	LocalBackupPath         string   `json:"local_backup_path"`
+	BackupOptions           []string `json:"backup_options"`
+	RestoreOptions          []string `json:"restore_options"`
 }
 
 type TimeoutDuration struct {
@@ -165,6 +167,12 @@ func Get() *Config {
 				}
 				if len(serviceConfig.LocalBackupPath) > 0 {
 					mergedServiceConfig.LocalBackupPath = serviceConfig.LocalBackupPath
+				}
+				if len(serviceConfig.BackupOptions) > 0 {
+					mergedServiceConfig.BackupOptions = serviceConfig.BackupOptions
+				}
+				if len(serviceConfig.RestoreOptions) > 0 {
+					mergedServiceConfig.RestoreOptions = serviceConfig.RestoreOptions
 				}
 				config.Services[serviceName] = mergedServiceConfig
 			}

--- a/service/mysql/backup.go
+++ b/service/mysql/backup.go
@@ -58,6 +58,9 @@ func Backup(ctx context.Context, s3 *s3.Client, service util.Service, binding *c
 		command = append(command, "--all-databases")
 	}
 
+	command = append(command, service.BackupOptions...)
+
+
 	log.Debugf("executing mysql backup command: %v", strings.Join(command, " "))
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 

--- a/service/mysql/restore.go
+++ b/service/mysql/restore.go
@@ -44,6 +44,8 @@ func Restore(ctx context.Context, s3 *s3.Client, service util.Service, binding *
 		command = append(command, "--force")
 	}
 
+	command = append(command, service.RestoreOptions...)
+
 	log.Debugf("executing mysql restore command: %v", strings.Join(command, " "))
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 

--- a/service/service.go
+++ b/service/service.go
@@ -111,6 +111,8 @@ func (s *Service) parseServices() {
 					DisableColumnStatistics: config.Get().Services[service.Name].DisableColumnStatistics,
 					ForceImport:             config.Get().Services[service.Name].ForceImport,
 					LocalBackupPath:         config.Get().Services[service.Name].LocalBackupPath,
+					BackupOptions:           config.Get().Services[service.Name].BackupOptions,
+					RestoreOptions:          config.Get().Services[service.Name].RestoreOptions,
 				}
 				s.Services = append(s.Services, newService)
 			}

--- a/service/util/service.go
+++ b/service/util/service.go
@@ -14,6 +14,8 @@ type Service struct {
 	DisableColumnStatistics bool
 	ForceImport             bool
 	LocalBackupPath         string
+	BackupOptions           []string
+	RestoreOptions          []string
 }
 type Retention struct {
 	Days  int


### PR DESCRIPTION
Hi,
This PR adds custom backup and restore options passed to mysqldump.
User may specify two arrays of strings in the configuration - **backup_options** and **restore_options**

