### PR TITLE
feature: Implement Microsoft Teams notifications for backups

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,9 +20,10 @@ type Config struct {
 	LoggingTimestamp   bool   `json:"logging_timestamp"`
 	Username           string
 	Password           string
-	DisableWeb         bool `json:"disable_web"`
-	DisableMetrics     bool `json:"disable_metrics"`
-	UnprotectedMetrics bool `json:"unprotected_metrics"`
+	DisableWeb         bool               `json:"disable_web"`
+	DisableMetrics     bool               `json:"disable_metrics"`
+	UnprotectedMetrics bool               `json:"unprotected_metrics"`
+	Notifications      NotificationConfig `json:"notifications"`
 	S3                 S3Config
 	Services           map[string]ServiceConfig
 	Foreground         bool
@@ -50,6 +51,14 @@ type ServiceConfig struct {
 	LocalBackupPath         string   `json:"local_backup_path"`
 	BackupOptions           []string `json:"backup_options"`
 	RestoreOptions          []string `json:"restore_options"`
+}
+
+type NotificationConfig struct {
+	Teams *TeamsNotificationConfig `json:"teams,omitempty"`
+}
+
+type TeamsNotificationConfig struct {
+	Webhook string `json:"webhook"`
 }
 
 type TimeoutDuration struct {
@@ -195,16 +204,22 @@ func Get() *Config {
 		}
 
 		// use username & password from env if defined
-		if len(os.Getenv("BACKMAN_USERNAME")) > 0 {
-			config.Username = os.Getenv("BACKMAN_USERNAME")
+		if os.Getenv(BackmanUsername) != "" {
+			config.Username = os.Getenv(BackmanUsername)
 		}
-		if len(os.Getenv("BACKMAN_PASSWORD")) > 0 {
-			config.Password = os.Getenv("BACKMAN_PASSWORD")
+		if os.Getenv(BackmanPassword) != "" {
+			config.Password = os.Getenv(BackmanPassword)
 		}
 
 		// use s3 encryption key from env if defined
-		if len(os.Getenv("BACKMAN_ENCRYPTION_KEY")) > 0 {
-			config.S3.EncryptionKey = os.Getenv("BACKMAN_ENCRYPTION_KEY")
+		if os.Getenv(BackmanEncryptionKey) != "" {
+			config.S3.EncryptionKey = os.Getenv(BackmanEncryptionKey)
+		}
+
+		if os.Getenv(BackmanTeamsWebhook) != "" {
+			config.Notifications.Teams = &TeamsNotificationConfig{
+				Webhook: os.Getenv(BackmanTeamsWebhook),
+			}
 		}
 	})
 	return &config

--- a/config/const.go
+++ b/config/const.go
@@ -1,0 +1,6 @@
+package config
+
+const BackmanUsername = "BACKMAN_USERNAME"
+const BackmanPassword = "BACKMAN_PASSWORD"
+const BackmanEncryptionKey = "BACKMAN_ENCRYPTION_KEY"
+const BackmanTeamsWebhook = "BACKMAN_TEAMS_WEBHOOK"

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/swisscom/backman
 go 1.16
 
 require (
+	github.com/atc0005/go-teams-notify/v2 v2.6.0
 	github.com/cloudfoundry-community/go-cfenv v1.18.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -19,7 +20,6 @@ require (
 	github.com/prometheus/common v0.20.0 // indirect
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.8.1
-	github.com/stretchr/testify v1.6.1 // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1 // indirect
 	golang.org/x/sys v0.0.0-20210412220455-f1c623a9e750 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
+github.com/atc0005/go-teams-notify/v2 v2.6.0 h1:YegKDWbjlatR0fP2yHsQYXzTcUGNJXhm1/OiCgbyysc=
+github.com/atc0005/go-teams-notify/v2 v2.6.0/go.mod h1:xo6GejLDHn3tWBA181F8LrllIL0xC1uRsRxq7YNXaaY=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
@@ -319,8 +321,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=

--- a/notification/events.go
+++ b/notification/events.go
@@ -1,0 +1,9 @@
+package notification
+
+type Event string
+
+const (
+	BackupStarted    Event = "backup-started"
+	BackupSuccessful Event = "backup-success"
+	BackupFailed     Event = "backup-fail"
+)

--- a/notification/notification.go
+++ b/notification/notification.go
@@ -1,0 +1,105 @@
+package notification
+
+import (
+	"fmt"
+	"github.com/atc0005/go-teams-notify/v2"
+	"github.com/swisscom/backman/config"
+	"github.com/swisscom/backman/log"
+	"github.com/swisscom/backman/service/util"
+	"sync"
+)
+
+var (
+	notificationService *Service
+	once                sync.Once
+)
+
+type Service struct {
+	config config.NotificationConfig
+
+	teamsApi *goteamsnotify.API
+}
+
+func (s Service) Send(event Event, service util.Service, filename string) {
+	if s.config.Teams != nil {
+		err := s.sendTeamsNotification(event, service, filename)
+		if err != nil {
+			log.Errorf("unable to send Microsoft Teams notification: %v", err)
+		}
+	}
+}
+
+func (s Service) sendTeamsNotification(event Event, service util.Service, filename string) (error) {
+	if s.teamsApi == nil {
+		return fmt.Errorf(
+			"Teams client is not initialized properly, %s notification will not be sent",
+			event,
+		)
+	}
+	teamsClient := *s.teamsApi
+	var card *goteamsnotify.MessageCard
+	var err error
+	switch event {
+	case BackupStarted:
+		card, err = getMessageCard(
+			fmt.Sprintf("Backup of %s started", service.Name),
+			fmt.Sprintf(
+				"Backman is starting to backup _%s_",
+				service.Name,
+			),
+			ColorInfo,
+		)
+	case BackupSuccessful:
+		card, err = getMessageCard(
+			fmt.Sprintf("Backup of %s successful!", service.Name),
+			fmt.Sprintf(
+				"Backman successfully completed a backup of _%s_ creating `%s`",
+				service.Name,
+				filename,
+			),
+			ColorSuccess,
+		)
+	case BackupFailed:
+		card, err = getMessageCard(
+			fmt.Sprintf("Backup of %s failed!", service.Name),
+			fmt.Sprintf(
+				"Backman failed to complete the backup of _%s_!",
+				service.Name,
+			),
+			ColorFail,
+		)
+	default:
+		return fmt.Errorf("unrecongized event %s", event)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if card == nil {
+		return fmt.Errorf("card cannot be nil")
+	}
+
+	err = teamsClient.Send(s.config.Teams.Webhook, *card)
+	if err != nil {
+		return fmt.Errorf("unable to send Microsoft Teams message: %v", err)
+	}
+	return nil
+}
+
+func (s *Service) initializeTeams() {
+	client := goteamsnotify.NewClient()
+	s.teamsApi = &client
+}
+
+func newNotificationService(config *config.Config) *Service {
+	return &Service{config: config.Notifications}
+}
+
+func Manager() *Service {
+	once.Do(func() {
+		notificationService = newNotificationService(config.Get())
+		notificationService.initializeTeams()
+	})
+	return notificationService
+}

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -1,0 +1,42 @@
+package notification_test
+
+import (
+	"github.com/swisscom/backman/notification"
+	"github.com/swisscom/backman/service/util"
+	"testing"
+)
+
+func TestSendNotificationBackupSucceeded(t *testing.T){
+	n := notification.Manager()
+	n.Send(notification.BackupSuccessful, util.Service{
+		Name:                    "some-mongodb",
+		Label:                   "label",
+		Plan:                    "small3rs",
+		Tags:                    nil,
+		Timeout:                 10,
+		Schedule:                "",
+		Retention:               util.Retention{},
+		DirectS3:                false,
+		DisableColumnStatistics: false,
+		ForceImport:             false,
+		LocalBackupPath:         "",
+		BackupOptions:           nil,
+		RestoreOptions:          nil,
+	}, "some-mongodb_20210714144020.gz")
+
+	n.Send(notification.BackupFailed, util.Service{
+		Name:                    "some-mongodb",
+		Label:                   "label",
+		Plan:                    "small3rs",
+		Tags:                    nil,
+		Timeout:                 10,
+		Schedule:                "",
+		Retention:               util.Retention{},
+		DirectS3:                false,
+		DisableColumnStatistics: false,
+		ForceImport:             false,
+		LocalBackupPath:         "",
+		BackupOptions:           nil,
+		RestoreOptions:          nil,
+	}, "some-mongodb_20210714144020.gz")
+}

--- a/notification/teams.go
+++ b/notification/teams.go
@@ -1,0 +1,28 @@
+package notification
+
+import (
+	"fmt"
+	goteamsnotify "github.com/atc0005/go-teams-notify/v2"
+)
+
+type Color string
+
+const (
+	ColorSuccess Color = "#0eaba9" // Swisscom Turquoise
+	ColorFail    Color = "#e61e64" // Swisscom Magenta
+	ColorInfo    Color = "#001155" // Swisscom Navy
+)
+
+func getMessageCard(title string, text string, color Color) (*goteamsnotify.MessageCard, error) {
+	messageCard := goteamsnotify.NewMessageCard()
+	messageCard.Title = title
+	messageCard.ThemeColor = string(color)
+	section := goteamsnotify.NewMessageCardSection()
+	section.Text = text
+	err := messageCard.AddSection(section)
+	if err != nil {
+		return nil, fmt.Errorf("unable to add section: %v", err)
+	}
+	messageCard.Summary = section.Text
+	return &messageCard, nil
+}

--- a/state/backup.go
+++ b/state/backup.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"github.com/swisscom/backman/notification"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -58,7 +59,8 @@ func BackupStart(service util.Service, filename string) {
 			Status:    "running",
 			Filename:  filename,
 			At:        time.Now(),
-		})
+	})
+	notification.Manager().Send(notification.BackupStarted, service, filename)
 }
 
 func BackupFailure(service util.Service, filename string) {
@@ -73,7 +75,8 @@ func BackupFailure(service util.Service, filename string) {
 			Filename:  filename,
 			At:        time.Now(),
 			Duration:  time.Since(state.At),
-		})
+	})
+	notification.Manager().Send(notification.BackupFailed, service, filename)
 }
 
 func BackupSuccess(service util.Service, filename string) {
@@ -89,4 +92,6 @@ func BackupSuccess(service util.Service, filename string) {
 			At:        time.Now(),
 			Duration:  time.Since(state.At),
 		})
+
+	notification.Manager().Send(notification.BackupSuccessful, service, filename)
 }

--- a/vendor/github.com/atc0005/go-teams-notify/v2/.gitignore
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/.gitignore
@@ -1,0 +1,30 @@
+# Copyright 2020 Enrico Hoffmann
+# Copyright 2021 Adam Chalkley
+#
+# https://github.com/atc0005/go-teams-notify
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# refs GH-6, GH-15
+# Allow vendored files to be included in this repo
+#vendor
+
+# Ignore local scratch directory
+/scratch
+
+# Ignore local Visual Studio Code settings
+/.vscode

--- a/vendor/github.com/atc0005/go-teams-notify/v2/.golangci.yml
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/.golangci.yml
@@ -1,0 +1,90 @@
+# Copyright 2020 Enrico Hoffmann
+# Copyright 2021 Adam Chalkley
+#
+# https://github.com/atc0005/go-teams-notify
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+linters:
+  enable:
+    - dogsled
+    - dupl
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - revive
+    - gosec
+
+    # Deprecated linter, but still functional as of golangci-lint v1.39.0.
+    # See https://github.com/atc0005/go-ci/issues/302 for more information.
+    - maligned
+    - nakedret
+    - prealloc
+    - exportloopref
+    - unconvert
+    - unparam
+    - whitespace
+
+linters-settings:
+  funlen:
+    lines: 60
+    statements: 40
+
+  gocognit:
+    # minimal code complexity to report, 30 by default (but we recommend 10-20)
+    min-complexity: 10
+
+  gocyclo:
+    # minimal code complexity to report, 30 by default (but we recommend 10-20)
+    min-complexity: 15
+
+  maligned:
+    # print struct with more effective memory layout or not, false by default
+    suggest-new: true
+
+  nakedret:
+    # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
+    max-func-lines: 2
+
+  unparam:
+    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
+    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
+    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
+    # with golangci-lint call it on a directory with the changed file.
+    check-exported: true
+
+  unused:
+    # treat code as a program (not a library) and report unused exported identifiers; default is false.
+    # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
+    # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
+    # with golangci-lint call it on a directory with the changed file.
+    check-exported: false
+
+  whitespace:
+    # Enforces newlines (or comments) after every multi-line if statement
+    multi-if: true
+    # Enforces newlines (or comments) after every multi-line function signature
+    multi-func: true
+
+issues:
+  # Not using default exclusions because we want to require comments on public
+  # functions and types.
+  exclude-use-default: false
+
+# options for analysis running
+run:
+  # include test files or not, default is true
+  tests: false
+
+  # by default isn't set. If set we pass it to "go list -mod={option}". From "go help modules":
+  # If invoked with -mod=readonly, the go command is disallowed from the implicit
+  # automatic updating of go.mod described above. Instead, it fails when any changes
+  # to go.mod are needed. This setting is most useful to check that go.mod does
+  # not need updates, such as in a continuous integration and testing system.
+  # If invoked with -mod=vendor, the go command assumes that the vendor
+  # directory holds the correct copies of dependencies and ignores
+  # the dependency descriptions in go.mod.
+  modules-download-mode: vendor

--- a/vendor/github.com/atc0005/go-teams-notify/v2/.markdownlint.yml
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/.markdownlint.yml
@@ -1,0 +1,22 @@
+# Copyright 2021 Adam Chalkley
+#
+# https://github.com/atc0005/go-teams-notify
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# https://github.com/igorshubovych/markdownlint-cli#configuration
+# https://github.com/DavidAnson/markdownlint#optionsconfig
+
+# Setting the special default rule to true or false includes/excludes all
+# rules by default.
+"default": true
+
+# We know that line lengths will be long in the main README file, so don't
+# report those cases.
+"MD013": false
+
+# Don't complain if sub-heading names are duplicated since this is a common
+# practice in CHANGELOG.md (e.g., "Fixed").
+"MD024":
+  "siblings_only": true

--- a/vendor/github.com/atc0005/go-teams-notify/v2/CHANGELOG.md
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/CHANGELOG.md
@@ -1,0 +1,407 @@
+# Changelog
+
+## Overview
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a
+Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Please [open an issue](https://github.com/atc0005/go-teams-notify/issues) for any
+deviations that you spot; I'm still learning!.
+
+## Types of changes
+
+The following types of changes will be recorded in this file:
+
+- `Added` for new features.
+- `Changed` for changes in existing functionality.
+- `Deprecated` for soon-to-be removed features.
+- `Removed` for now removed features.
+- `Fixed` for any bug fixes.
+- `Security` in case of vulnerabilities.
+
+## [Unreleased]
+
+- placeholder
+
+## [v2.6.0] - 2021-07-09
+
+### Added
+
+- Features
+  - Add support for PotentialActions (aka, "Actions")
+    - credit: [@nmaupu](https://github.com/nmaupu)
+
+- Documentation
+  - Add separate `examples` directory containing standalone example code for
+    most common use cases
+
+### Changed
+
+- Dependencies
+  - `actions/setup-node`
+    - `v2.1.5` to `v2.2.0`
+    - update `node-version` value to always use latest LTS version instead of
+      hard-coded version
+
+- Linting
+  - replace `golint`, `scopelint` linters, cleanup config
+    - note: this specifically applies to linting performed via Makefile
+      recipe, not (at present) the bulk of the CI linting checks
+
+- Documentation
+  - move examples from README to separate `examples` directory
+  - Remove example from doc.go file, direct reader to main README
+  - Update project status
+    - remove history as it is likely no longer relevant (original
+      project is discontinued at this point)
+    - remove future (for the same reason)
+  - Add explicit "Supported Releases" section to help make clear that
+    the v1 series is no longer maintained
+  - Remove explicit "used by" details, rely on dynamic listing provided
+    by pkg.go.dev instead
+  - Minor polish
+
+## [v2.5.0] - 2021-04-08
+
+### Added
+
+- Features
+  - Validation of webhook URLs using custom validation patterns
+    - credit: [@nmaupu](https://github.com/nmaupu)
+  - Validation of `MessageCard` type using a custom validation function (to
+      override default validation behavior)
+    - credit: [@nmaupu](https://github.com/nmaupu)
+
+- Documentation
+  - Add list of projects using this library
+  - Update features list to include functionality added to this fork
+    - Configurable validation of webhook URLs
+    - Configurable validation of `MessageCard` type
+    - Configurable timeouts
+    - Configurable retry support
+
+### Changed
+
+- Dependencies
+  - `actions/setup-node`
+    - `v2.1.4` to `v2.1.5`
+
+### Fixed
+
+- Documentation
+  - Misc typos
+  - Grammatical tweaks
+  - Attempt to clarify project status
+    - i.e., not mothballed, just slow cadence
+
+## [v2.4.2] - 2021-01-28
+
+### Changed
+
+- Apply regex pattern match for webhook URL validation instead of fixed
+  strings in order to support matching private org webhook URL subdomains
+
+### Fixed
+
+- Updating an exiting webhook connector in Microsoft Teams switches the URL to
+  unsupported `https://*.webhook.office.com/webhookb2/` format
+- `SendWithRetry` method does not honor setting to disable webhook URL prefix
+  validation
+- Support for disabling webhook URL validation limited to just disabling
+  validation of prefixes
+
+## [v2.4.1] - 2021-01-28
+
+### Changed
+
+- (GH-59) Webhook URL API endpoint response validation now requires a `1` text
+  string as the response body
+
+### Fixed
+
+- (GH-59) Microsoft Teams Webhook Connector "200 OK" status insufficient
+  indication of success
+
+## [v2.4.0] - 2021-01-28
+
+### Added
+
+- Add (optional) support for disabling webhook URL prefix validation
+  - credit: [@odise](https://github.com/odise)
+
+### Changed
+
+- Documentation
+  - Refresh "basic" example
+  - Add example for disabling webhook URL prefix validation
+  - Update "about this project" coverage
+  - Swap GoDoc badge for pkg.go.dev badge
+
+- Tests
+  - Extend test coverage
+  - Verbose test output by default (Makefile, GitHub Actions Workflow)
+
+- Dependencies
+  - `actions/setup-node`
+    - `v2.1.1` to `v2.1.4`
+  - `actions/checkout`
+    - `v2.3.2` to `v2.3.4`
+  - `stretchr/testify`
+    - `v1.6.1` to `v1.7.0`
+
+### Fixed
+
+- minor linting error for commented code
+- Tests fail to assert that any errors which occur are expected, only the
+  types
+
+## [v2.3.0] - 2020-08-29
+
+### Added
+
+- Add package-level logging for formatting functions
+  - as with other package-level logging, this is disabled by default
+
+- API
+  - add `SendWithRetry` method based on the `teams.SendMessage` function from
+    the `atc0005/send2teams` project
+    - actively working to move relevant content from that project to this one
+
+### Fixed
+
+- YYYY-MM-DD date formatting of changelog version entries
+
+## [v2.2.0] - 2020-08-28
+
+### Added
+
+- Add package-level logger
+- Extend API to allow request cancellation via context
+- Add formatting functions useful for text conversion
+  - Convert Windows/Mac/Linux EOL to Markdown break statements
+    - used to provide equivalent Teams-compatible formatting
+  - Format text as code snippet
+    - this inserts leading and trailing ` character to provide Markdown string
+      formatting
+  - Format text as code block
+    - this inserts three leading and trailing ` characters to provide Markdown
+      code block formatting
+  - *`Try`* variants of code formatting functions
+    - return formatted string if no errors, otherwise return the original
+      string
+
+### Changed
+
+- Expose API response strings containing potential error messages
+- README
+  - Explicitly note that this fork is now standalone until such time that the
+    upstream project resumes development/maintenance efforts
+
+### Fixed
+
+- CHANGELOG section link in previous release
+- Invalid `RoundTripper` implementation used in `TestTeamsClientSend` test
+  function
+  - see `GH-46` and `GH-47`; thank you `@davecheney` for the fix!
+
+## [v2.1.1] - 2020-08-25
+
+### Added
+
+- README
+  - Add badges for GitHub Actions Workflows
+  - Add release badge for latest project release
+- Add CHANGELOG file
+- Add GoDoc package-level documentation
+- Extend webhook validation error handling
+- Add Docker-based GitHub Actions Workflows
+- Enable Dependabot updates
+- Add Markdownlint config file
+
+### Changed
+
+- README
+  - Replace badge for latest tag with latest release
+  - Update GoDoc badge to reference this fork
+  - Update license badge to reference this fork
+  - Add new sections common to other projects that I maintain
+    - table of contents
+    - overview
+    - changelog
+    - references
+    - features
+- Vendor dependencies
+- Update license to add @atc0005 (new) in addition to @dasrick (existing)
+- Update go.mod to replace upstream with this fork
+- Rename golangci-lint config file to match officially supported name
+- Remove files no longer used by this fork
+  - Travis CI configuration
+  - editorconfig file (and settings)
+- Add license header to source files
+  - combined copyright statement for existing files
+  - single copyright statement for new files
+
+### Fixed
+
+- Add missing Facts assignment in MessageCardSection
+- scopelint: Fix improper range loop var reference
+- Fix misc linting issues with README
+- Test failure from previous upstream pull request submissions
+  - `Object expected to be of type *url.Error, but was *errors.errorString`
+- Misc linting issues with primary and test files
+
+## [v2.1.0] - 2020-04-08
+
+### Added
+
+- `MessageCard` type includes additional fields
+  - `Type` and `Context` fields provide required JSON payload
+    fields
+    - preset to required static values via updated
+      `NewMessageCard()` constructor
+  - `Summary`
+    - required if `Text` field is not set, optional otherwise
+  - `Sections` slice
+    - `MessageCardSection` type
+
+- Additional nested types
+  - `MessageCardSection`
+  - `MessageCardSectionFact`
+  - `MessageCardSectionImage`
+
+- Additional methods for `MessageCard` and nested types
+  - `MessageCard.AddSection()`
+  - `MessageCardSection.AddFact()`
+  - `MessageCardSection.AddFactFromKeyValue()`
+  - `MessageCardSection.AddImage()`
+  - `MessageCardSection.AddHeroImageStr()`
+  - `MessageCardSection.AddHeroImage()`
+
+- Additional factory functions
+  - `NewMessageCardSection()`
+  - `NewMessageCardSectionFact()`
+  - `NewMessageCardSectionImage()`
+
+- `IsValidMessageCard()` added to check for minimum required
+    field values.
+  - This function has the potential to be extended
+    later with additional validation steps.
+
+- Wrapper `IsValidInput()` added to handle all validation
+  needs from one location.
+  - the intent was to both solve a CI erro and provide
+    a location to easily extend validation checks in
+    the future (if needed)
+
+### Changed
+
+- `MessageCard` type includes additional fields
+- `NewMessageCard` factory function sets fields needed for
+   required JSON payload fields
+  - `Type`
+  - `Context`
+
+- `teamsClient.Send()` method updated to apply `MessageCard` struct
+  validation alongside existing webhook URL validation
+
+- `isValidWebhookURL()` exported as `IsValidWebhookURL()` so that client
+  code can use the validation functionality instead of repeating the
+  code
+  - e.g., flag value validation for "fail early" behavior
+
+### Known Issues
+
+- No support in this set of changes for `potentialAction` types
+  - `ViewAction`
+  - `OpenUri`
+  - `HttpPOST`
+  - `ActionCard`
+  - `InvokeAddInCommand`
+    - Outlook specific based on what I read; likely not included
+      in a future release due to non-Teams specific usage
+
+## [v2.0.0] - 2020-03-29
+
+### Breaking
+
+- `NewClient()` will NOT return multiple values
+- remove provided mock
+
+### Changed
+
+- switch dependency/package management tool to from `dep` to `go mod`
+- switch from `golint` to `golangci-lint`
+- add more golang versions to pass via travis-ci
+
+## [v1.3.1] - 2020-03-29
+
+### Fixed
+
+- fix redundant error logging
+- fix redundant comment
+
+## [v1.3.0] - 2020-03-26
+
+### Changed
+
+- feature: allow multiple valid webhook URL FQDNs (thx @atc0005)
+
+## [v1.2.0] - 2019-11-08
+
+### Added
+
+- add mock
+
+### Changed
+
+- update deps
+- `gosimple` (shorten two conditions)
+
+## [v1.1.1] - 2019-05-02
+
+### Changed
+
+- rename client interface into API
+- update deps
+
+### Fixed
+
+- fix typo in README
+
+## [v1.1.0] - 2019-04-30
+
+### Added
+
+- add missing tests
+- append documentation
+
+### Changed
+
+- add/change to client/interface
+
+## [v1.0.0] - 2019-04-29
+
+### Added
+
+- add initial functionality of sending messages to MS Teams channel
+
+[Unreleased]: https://github.com/atc0005/go-teams-notify/compare/v2.6.0...HEAD
+[v2.6.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.6.0
+[v2.5.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.5.0
+[v2.4.2]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.4.2
+[v2.4.1]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.4.1
+[v2.4.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.4.0
+[v2.3.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.3.0
+[v2.2.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.2.0
+[v2.1.1]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.1.1
+[v2.1.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.1.0
+[v2.0.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v2.0.0
+[v1.3.1]: https://github.com/atc0005/go-teams-notify/releases/tag/v1.3.1
+[v1.3.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v1.3.0
+[v1.2.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v1.2.0
+[v1.1.1]: https://github.com/atc0005/go-teams-notify/releases/tag/v1.1.1
+[v1.1.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v1.1.0
+[v1.0.0]: https://github.com/atc0005/go-teams-notify/releases/tag/v1.0.0

--- a/vendor/github.com/atc0005/go-teams-notify/v2/LICENSE
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2020 Enrico Hoffmann
+Copyright (c) 2020-Present Adam Chalkley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/atc0005/go-teams-notify/v2/Makefile
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/Makefile
@@ -1,0 +1,108 @@
+# Copyright 2020 Enrico Hoffmann
+# Copyright 2021 Adam Chalkley
+#
+# https://github.com/atc0005/go-teams-notify
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# REFERENCES
+#
+# https://github.com/golangci/golangci-lint#install
+# https://github.com/golangci/golangci-lint/releases/latest
+
+SHELL = /bin/bash
+
+BUILDCMD				=	go build -mod=vendor ./...
+GOCLEANCMD				=	go clean -mod=vendor ./...
+GITCLEANCMD				= 	git clean -xfd
+CHECKSUMCMD				=	sha256sum -b
+
+.DEFAULT_GOAL := help
+
+  ##########################################################################
+  # Targets will not work properly if a file with the same name is ever
+  # created in this directory. We explicitly declare our targets to be phony
+  # by making them a prerequisite of the special target .PHONY
+  ##########################################################################
+
+.PHONY: help
+## help: prints this help message
+help:
+	@echo "Usage:"
+	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' |  sed -e 's/^/ /'
+
+.PHONY: lintinstall
+## lintinstall: install common linting tools
+# https://github.com/golang/go/issues/30515#issuecomment-582044819
+lintinstall:
+	@echo "Installing linting tools"
+
+	@export PATH="${PATH}:$(go env GOPATH)/bin"
+
+	@echo "Explicitly enabling Go modules mode per command"
+	(cd; GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck)
+
+	@echo Installing latest stable golangci-lint version per official installation script ...
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin
+	golangci-lint --version
+
+	@echo "Finished updating linting tools"
+
+.PHONY: linting
+## linting: runs common linting checks
+linting:
+	@echo "Running linting tools ..."
+
+	@echo "Running go vet ..."
+	@go vet -mod=vendor $(shell go list -mod=vendor ./... | grep -v /vendor/)
+
+	@echo "Running golangci-lint ..."
+	@golangci-lint run
+
+	@echo "Running staticcheck ..."
+	@staticcheck $(shell go list -mod=vendor ./... | grep -v /vendor/)
+
+	@echo "Finished running linting checks"
+
+.PHONY: gotests
+## gotests: runs go test recursively, verbosely
+gotests:
+	@echo "Running go tests ..."
+	@go test -v -mod=vendor ./...
+	@echo "Finished running go tests"
+
+.PHONY: goclean
+## goclean: removes local build artifacts, temporary files, etc
+goclean:
+	@echo "Removing object files and cached files ..."
+	@$(GOCLEANCMD)
+
+.PHONY: clean
+## clean: alias for goclean
+clean: goclean
+
+.PHONY: gitclean
+## gitclean: WARNING - recursively cleans working tree by removing non-versioned files
+gitclean:
+	@echo "Removing non-versioned files ..."
+	@$(GITCLEANCMD)
+
+.PHONY: pristine
+## pristine: run goclean and gitclean to remove local changes
+pristine: goclean gitclean
+
+.PHONY: all
+# https://stackoverflow.com/questions/3267145/makefile-execute-another-target
+## all: run all applicable build steps
+all: clean build
+	@echo "Completed build process ..."
+
+.PHONY: build
+## build: ensure that packages build
+build:
+	@echo "Building packages ..."
+
+	$(BUILDCMD)
+
+	@echo "Completed build tasks"

--- a/vendor/github.com/atc0005/go-teams-notify/v2/README.md
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/README.md
@@ -1,0 +1,243 @@
+<!-- omit in toc -->
+# go-teams-notify
+
+A package to send messages to Microsoft Teams (channels)
+
+[![Latest release][githubtag-image]][githubtag-url]
+[![Go Reference][goref-image]][goref-url]
+[![License][license-image]][license-url]
+[![Validate Codebase](https://github.com/atc0005/go-teams-notify/workflows/Validate%20Codebase/badge.svg)](https://github.com/atc0005/go-teams-notify/actions?query=workflow%3A%22Validate+Codebase%22)
+[![Validate Docs](https://github.com/atc0005/go-teams-notify/workflows/Validate%20Docs/badge.svg)](https://github.com/atc0005/go-teams-notify/actions?query=workflow%3A%22Validate+Docs%22)
+[![Lint and Build using Makefile](https://github.com/atc0005/go-teams-notify/workflows/Lint%20and%20Build%20using%20Makefile/badge.svg)](https://github.com/atc0005/go-teams-notify/actions?query=workflow%3A%22Lint+and+Build+using+Makefile%22)
+[![Quick Validation](https://github.com/atc0005/go-teams-notify/workflows/Quick%20Validation/badge.svg)](https://github.com/atc0005/go-teams-notify/actions?query=workflow%3A%22Quick+Validation%22)
+
+<!-- omit in toc -->
+## Table of contents
+
+- [Project home](#project-home)
+- [Overview](#overview)
+- [Features](#features)
+- [Project Status](#project-status)
+- [Supported Releases](#supported-releases)
+- [Changelog](#changelog)
+- [Usage](#usage)
+  - [Add this project as a dependency](#add-this-project-as-a-dependency)
+  - [Webhook URLs](#webhook-urls)
+    - [Expected format](#expected-format)
+    - [How to create a webhook URL (Connector)](#how-to-create-a-webhook-url-connector)
+  - [Examples](#examples)
+    - [Basic](#basic)
+    - [Add an Action](#add-an-action)
+    - [Disable webhook URL prefix validation](#disable-webhook-url-prefix-validation)
+    - [Enable custom patterns' validation](#enable-custom-patterns-validation)
+- [Used by](#used-by)
+- [References](#references)
+
+## Project home
+
+See [our GitHub repo](https://github.com/atc0005/go-teams-notify) for the
+latest code, to file an issue or submit improvements for review and potential
+inclusion into the project.
+
+## Overview
+
+The `goteamsnotify` package (aka, `go-teams-notify`) allows sending messages
+to a Microsoft Teams channel.
+
+Simple messages can be composed of only a title and a text body. More complex
+messages can be composed of multiple sections, key/value pairs (aka, `Facts`)
+and/or externally hosted images. See the [Features](#features) list for more
+information.
+
+## Features
+
+- Submit simple or complex messages to Microsoft Teams
+  - simple messages consist of only a title and a text body (one or more
+    strings)
+  - complex messages consist of one or more sections, key/value pairs (aka,
+    `Facts`) and/or externally hosted images. or images (hosted externally)
+- Support for [`Actions`][msgcard-ref-actions], allowing users to take quick
+  actions within Microsoft Teams
+- Configurable validation of webhook URLs
+  - enabled by default, attempts to match most common known webhook URL
+    patterns
+  - option to disable validation entirely
+  - option to use custom validation patterns
+- Configurable validation of `MessageCard` type
+  - default assertion that bare-minimum required fields are present
+  - support for providing a custom validation function to override default
+    validation behavior
+- Configurable timeouts
+- Configurable retry support
+
+## Project Status
+
+In short:
+
+- The upstream project is no longer being actively developed or maintained.
+- This fork is now a standalone project, accepting contributions, bug reports
+  and feature requests.
+- Others have also taken an interest in [maintaining their own
+  forks](https://github.com/atc0005/go-teams-notify/network/members) of the
+  original project. See those forks for other ideas/changes that you may find
+  useful.
+
+For more details, see the
+[Releases](https://github.com/atc0005/go-teams-notify/releases) section or our
+[Changelog](https://github.com/atc0005/go-teams-notify/blob/master/CHANGELOG.md).
+
+## Supported Releases
+
+| Series   | Example  | Status              |
+| -------- | -------- | ------------------- |
+| `v1.x.x` | `v1.3.1` | Not Supported (EOL) |
+| `v2.x.x` | `v2.6.0` | Supported           |
+
+## Changelog
+
+See the [`CHANGELOG.md`](CHANGELOG.md) file for the changes associated with
+each release of this application. Changes that have been merged to `master`,
+but not yet an official release may also be noted in the file under the
+`Unreleased` section. A helpful link to the Git commit history since the last
+official release is also provided for further review.
+
+## Usage
+
+### Add this project as a dependency
+
+Assuming that you're using [Go
+Modules](https://blog.golang.org/using-go-modules), add this line to your
+imports like so:
+
+```golang
+import (
+  // ...
+
+  "github.com/atc0005/go-teams-notify/v2"
+)
+```
+
+Depending on your editor and current settings, your editor may resolve the
+import and update your `go.mod` and `go.sum` files accordingly. If not, review
+these resources for further information:
+
+- <https://blog.golang.org/using-go-modules>
+- <https://golang.org/doc/modules/managing-dependencies>
+- <https://golang.org/ref/mod>
+
+See the [Examples](#examples) section for more details.
+
+### Webhook URLs
+
+#### Expected format
+
+Valid webhook URLs for Microsoft Teams use one of several (confirmed) FQDNs
+patterns:
+
+- `outlook.office.com`
+- `outlook.office365.com`
+- `*.webhook.office.com`
+  - e.g., `example.webhook.office.com`
+
+Using a webhook URL with any of these FQDN patterns appears to give identical
+results.
+
+Here are complete, equivalent example webhook URLs from Microsoft's
+documentation using the FQDNs above:
+
+- <https://outlook.office.com/webhook/a1269812-6d10-44b1-abc5-b84f93580ba0@9e7b80c7-d1eb-4b52-8582-76f921e416d9/IncomingWebhook/3fdd6767bae44ac58e5995547d66a4e4/f332c8d9-3397-4ac5-957b-b8e3fc465a8c>
+- <https://outlook.office365.com/webhook/a1269812-6d10-44b1-abc5-b84f93580ba0@9e7b80c7-d1eb-4b52-8582-76f921e416d9/IncomingWebhook/3fdd6767bae44ac58e5995547d66a4e4/f332c8d9-3397-4ac5-957b-b8e3fc465a8c>
+- <https://example.webhook.office.com/webhookb2/a1269812-6d10-44b1-abc5-b84f93580ba0@9e7b80c7-d1eb-4b52-8582-76f921e416d9/IncomingWebhook/3fdd6767bae44ac58e5995547d66a4e4/f332c8d9-3397-4ac5-957b-b8e3fc465a8c>
+  - note the `webhookb2` sub-URI specific to this FQDN pattern
+
+All of these patterns when provided to this library should pass the default
+validation applied. See the example further down for the option of disabling
+webhook URL validation entirely.
+
+#### How to create a webhook URL (Connector)
+
+1. Open Microsoft Teams
+1. Navigate to the channel where you wish to receive incoming messages from
+   this application
+1. Select `⋯` next to the channel name and then choose Connectors.
+1. Scroll through the list of Connectors to Incoming Webhook, and choose Add.
+1. Enter a name for the webhook, upload an image to associate with data from
+   the webhook, and choose Create.
+1. Copy the webhook URL to the clipboard and save it. You'll need the webhook
+   URL for sending information to Microsoft Teams.
+   - NOTE: While you can create another easily enough, you should treat this
+     webhook URL as sensitive information as anyone with this unique URL is
+     able to send messages (without authentication) into the associated
+     channel.
+1. Choose Done.
+
+Credit:
+[docs.microsoft.com](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using#setting-up-a-custom-incoming-webhook),
+[gist comment from
+shadabacc3934](https://gist.github.com/chusiang/895f6406fbf9285c58ad0a3ace13d025#gistcomment-3562501)
+
+### Examples
+
+#### Basic
+
+This is an example of a simple client application which uses this library.
+
+File: [basic](./examples/basic/main.go)
+
+#### Add an Action
+
+This example illustrates adding an [`OpenUri Action`][msgcard-ref-actions] to
+a message card. When used, this action triggers opening a URI in a separate
+browser or application.
+
+File: [actions](./examples/actions/main.go)
+
+#### Disable webhook URL prefix validation
+
+This example disables the validation webhook URLs, including the validation of
+known prefixes so that custom/private webhook URL endpoints can be used (e.g.,
+testing purposes).
+
+File: [disable-validation](./examples/disable-validation/main.go)
+
+#### Enable custom patterns' validation
+
+This example demonstrates how to enable custom validation patterns for webhook
+URLs.
+
+File: [custom-validation](./examples/custom-validation/main.go)
+
+## Used by
+
+See the Known importers lists below for a dynamically updated list of projects
+using either this library or the original project.
+
+- [this fork](https://pkg.go.dev/github.com/atc0005/go-teams-notify/v2?tab=importedby)
+- [original project](https://pkg.go.dev/github.com/dasrick/go-teams-notify/v2?tab=importedby)
+
+## References
+
+- [Original project](https://github.com/dasrick/go-teams-notify)
+- [Forks of original project](https://github.com/atc0005/go-teams-notify/network/members)
+
+- Microsoft Teams
+  - MS Teams - adaptive cards
+  ([de-de](https://docs.microsoft.com/de-de/outlook/actionable-messages/adaptive-card),
+  [en-us](https://docs.microsoft.com/en-us/outlook/actionable-messages/adaptive-card))
+  - MS Teams - send via connectors
+  ([de-de](https://docs.microsoft.com/de-de/outlook/actionable-messages/send-via-connectors),
+  [en-us](https://docs.microsoft.com/en-us/outlook/actionable-messages/send-via-connectors))
+  - [adaptivecards.io](https://adaptivecards.io/designer)
+  - [Legacy actionable message card reference][msgcard-ref]
+
+[githubtag-image]: https://img.shields.io/github/release/atc0005/go-teams-notify.svg?style=flat
+[githubtag-url]: https://github.com/atc0005/go-teams-notify
+
+[goref-image]: https://pkg.go.dev/badge/github.com/atc0005/go-teams-notify/v2.svg
+[goref-url]: https://pkg.go.dev/github.com/atc0005/go-teams-notify/v2
+
+[license-image]: https://img.shields.io/github/license/atc0005/go-teams-notify.svg?style=flat
+[license-url]: https://github.com/atc0005/go-teams-notify/blob/master/LICENSE
+
+[msgcard-ref]: <https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference>
+[msgcard-ref-actions]: <https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#actions>

--- a/vendor/github.com/atc0005/go-teams-notify/v2/doc.go
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/doc.go
@@ -1,0 +1,42 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/go-teams-notify
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+/*
+
+Package goteamsnotify is used to send messages to Microsoft Teams (channels)
+
+PROJECT HOME
+
+See our GitHub repo (https://github.com/atc0005/go-teams-notify) for the
+latest code, to file an issue or submit improvements for review and potential
+inclusion into the project.
+
+
+PURPOSE
+
+Send messages to a Microsoft Teams channel.
+
+
+FEATURES
+
+• Submit messages to Microsoft Teams consisting of one or more sections, Facts (key/value pairs), Actions or images (hosted externally)
+
+• Support for Actions, allowing users to take quick actions within Microsoft Teams
+
+• Configurable validation
+
+• Configurable timeouts
+
+• Configurable retry support
+
+
+USAGE
+
+See our main README for supported settings and examples.
+
+*/
+package goteamsnotify

--- a/vendor/github.com/atc0005/go-teams-notify/v2/format.go
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/format.go
@@ -1,0 +1,209 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/go-teams-notify
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package goteamsnotify
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+// Newline patterns stripped out of text content sent to Microsoft Teams (by
+// request) and replacement break value used to provide equivalent formatting.
+const (
+
+	// CR LF \r\n (windows)
+	windowsEOLActual  = "\r\n"
+	windowsEOLEscaped = `\r\n`
+
+	// CF \r (mac)
+	macEOLActual  = "\r"
+	macEOLEscaped = `\r`
+
+	// LF \n (unix)
+	unixEOLActual  = "\n"
+	unixEOLEscaped = `\n`
+
+	// Used by Teams to separate lines
+	breakStatement = "<br>"
+)
+
+// Even though Microsoft Teams doesn't show the additional newlines,
+// https://messagecardplayground.azurewebsites.net/ DOES show the results
+// as a formatted code block. Including the newlines now is an attempt at
+// "future proofing" the codeblock support in MessageCard values sent to
+// Microsoft Teams.
+const (
+
+	// msTeamsCodeBlockSubmissionPrefix is the prefix appended to text input
+	// to indicate that the text should be displayed as a codeblock by
+	// Microsoft Teams.
+	msTeamsCodeBlockSubmissionPrefix string = "\n```\n"
+	// msTeamsCodeBlockSubmissionPrefix string = "```"
+
+	// msTeamsCodeBlockSubmissionSuffix is the suffix appended to text input
+	// to indicate that the text should be displayed as a codeblock by
+	// Microsoft Teams.
+	msTeamsCodeBlockSubmissionSuffix string = "```\n"
+	// msTeamsCodeBlockSubmissionSuffix string = "```"
+
+	// msTeamsCodeSnippetSubmissionPrefix is the prefix appended to text input
+	// to indicate that the text should be displayed as a code formatted
+	// string of text by Microsoft Teams.
+	msTeamsCodeSnippetSubmissionPrefix string = "`"
+
+	// msTeamsCodeSnippetSubmissionSuffix is the suffix appended to text input
+	// to indicate that the text should be displayed as a code formatted
+	// string of text by Microsoft Teams.
+	msTeamsCodeSnippetSubmissionSuffix string = "`"
+)
+
+// TryToFormatAsCodeBlock acts as a wrapper for FormatAsCodeBlock. If an
+// error is encountered in the FormatAsCodeBlock function, this function will
+// return the original string, otherwise if no errors occur the newly formatted
+// string will be returned.
+func TryToFormatAsCodeBlock(input string) string {
+	result, err := FormatAsCodeBlock(input)
+	if err != nil {
+		logger.Printf("TryToFormatAsCodeBlock: error occurred when calling FormatAsCodeBlock: %v\n", err)
+		logger.Println("TryToFormatAsCodeBlock: returning original string")
+		return input
+	}
+
+	logger.Println("TryToFormatAsCodeBlock: no errors occurred when calling FormatAsCodeBlock")
+	return result
+}
+
+// TryToFormatAsCodeSnippet acts as a wrapper for FormatAsCodeSnippet. If
+// an error is encountered in the FormatAsCodeSnippet function, this function will
+// return the original string, otherwise if no errors occur the newly formatted
+// string will be returned.
+func TryToFormatAsCodeSnippet(input string) string {
+	result, err := FormatAsCodeSnippet(input)
+	if err != nil {
+		logger.Printf("TryToFormatAsCodeSnippet: error occurred when calling FormatAsCodeBlock: %v\n", err)
+		logger.Println("TryToFormatAsCodeSnippet: returning original string")
+		return input
+	}
+
+	logger.Println("TryToFormatAsCodeSnippet: no errors occurred when calling FormatAsCodeSnippet")
+	return result
+}
+
+// FormatAsCodeBlock accepts an arbitrary string, quoted or not, and calls a
+// helper function which attempts to format as a valid Markdown code block for
+// submission to Microsoft Teams
+func FormatAsCodeBlock(input string) (string, error) {
+	if input == "" {
+		return "", errors.New("received empty string, refusing to format")
+	}
+
+	result, err := formatAsCode(
+		input,
+		msTeamsCodeBlockSubmissionPrefix,
+		msTeamsCodeBlockSubmissionSuffix,
+	)
+
+	return result, err
+}
+
+// FormatAsCodeSnippet accepts an arbitrary string, quoted or not, and calls a
+// helper function which attempts to format as a single-line valid Markdown
+// code snippet for submission to Microsoft Teams
+func FormatAsCodeSnippet(input string) (string, error) {
+	if input == "" {
+		return "", errors.New("received empty string, refusing to format")
+	}
+
+	result, err := formatAsCode(
+		input,
+		msTeamsCodeSnippetSubmissionPrefix,
+		msTeamsCodeSnippetSubmissionSuffix,
+	)
+
+	return result, err
+}
+
+// formatAsCode is a helper function which accepts an arbitrary string, quoted
+// or not, a desired prefix and a suffix for the string and attempts to format
+// as a valid Markdown formatted code sample for submission to Microsoft Teams
+func formatAsCode(input string, prefix string, suffix string) (string, error) {
+	var err error
+	var byteSlice []byte
+
+	switch {
+	// required; protects against slice out of range panics
+	case input == "":
+		return "", errors.New("received empty string, refusing to format as code block")
+
+	// If the input string is already valid JSON, don't double-encode and
+	// escape the content
+	case json.Valid([]byte(input)):
+		logger.Printf("formatAsCode: input string already valid JSON; input: %+v", input)
+		logger.Printf("formatAsCode: Calling json.RawMessage([]byte(input)); input: %+v", input)
+
+		// FIXME: Is json.RawMessage() really needed if the input string is
+		// *already* JSON? https://golang.org/pkg/encoding/json/#RawMessage
+		// seems to imply a different use case.
+		byteSlice = json.RawMessage([]byte(input))
+		//
+		// From light testing, it appears to not be necessary:
+		//
+		// logger.Printf("formatAsCode: Skipping json.RawMessage, converting string directly to byte slice; input: %+v", input)
+		// byteSlice = []byte(input)
+
+	default:
+		logger.Printf("formatAsCode: input string not valid JSON; input: %+v", input)
+		logger.Printf("formatAsCode: Calling json.Marshal(input); input: %+v", input)
+		byteSlice, err = json.Marshal(input)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	logger.Println("formatAsCode: byteSlice as string:", string(byteSlice))
+
+	var prettyJSON bytes.Buffer
+
+	logger.Println("formatAsCode: calling json.Indent")
+	err = json.Indent(&prettyJSON, byteSlice, "", "\t")
+	if err != nil {
+		return "", err
+	}
+	formattedJSON := prettyJSON.String()
+
+	logger.Println("formatAsCode: Formatted JSON:", formattedJSON)
+
+	// handle both cases: where the formatted JSON string was not wrapped with
+	// double-quotes and when it was
+	codeContentForSubmission := prefix + strings.Trim(formattedJSON, "\"") + suffix
+
+	logger.Printf("formatAsCode: formatted JSON as-is:\n%s\n\n", formattedJSON)
+	logger.Printf("formatAsCode: formatted JSON wrapped with code prefix/suffix: \n%s\n\n", codeContentForSubmission)
+
+	// err should be nil if everything worked as expected
+	return codeContentForSubmission, err
+}
+
+// ConvertEOLToBreak converts \r\n (windows), \r (mac) and \n (unix) into <br>
+// HTML/Markdown break statements.
+func ConvertEOLToBreak(s string) string {
+	logger.Printf("ConvertEOLToBreak: Received %#v", s)
+
+	s = strings.ReplaceAll(s, windowsEOLActual, breakStatement)
+	s = strings.ReplaceAll(s, windowsEOLEscaped, breakStatement)
+	s = strings.ReplaceAll(s, macEOLActual, breakStatement)
+	s = strings.ReplaceAll(s, macEOLEscaped, breakStatement)
+	s = strings.ReplaceAll(s, unixEOLActual, breakStatement)
+	s = strings.ReplaceAll(s, unixEOLEscaped, breakStatement)
+
+	logger.Printf("ConvertEOLToBreak: Returning %#v", s)
+
+	return s
+}

--- a/vendor/github.com/atc0005/go-teams-notify/v2/go.mod
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/go.mod
@@ -1,0 +1,13 @@
+// Copyright 2020 Enrico Hoffmann
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/go-teams-notify
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+module github.com/atc0005/go-teams-notify/v2
+
+go 1.14
+
+require github.com/stretchr/testify v1.7.0

--- a/vendor/github.com/atc0005/go-teams-notify/v2/go.sum
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/vendor/github.com/atc0005/go-teams-notify/v2/messagecard.go
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/messagecard.go
@@ -1,0 +1,693 @@
+// Copyright 2020 Enrico Hoffmann
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/go-teams-notify
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package goteamsnotify
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	// PotentialActionOpenURIType is the type that must be used for OpenUri
+	// potential action.
+	PotentialActionOpenURIType = "OpenUri"
+
+	// PotentialActionHTTPPostType is the type that must be used for HttpPOST
+	// potential action.
+	PotentialActionHTTPPostType = "HttpPOST"
+
+	// PotentialActionActionCardType is the type that must be used for
+	// ActionCard potential action.
+	PotentialActionActionCardType = "ActionCard"
+
+	// PotentialActionInvokeAddInCommandType is the type that must be used for
+	// InvokeAddInCommand potential action.
+	PotentialActionInvokeAddInCommandType = "InvokeAddInCommand"
+
+	// PotentialActionActionCardInputTextInputType is the type that must be
+	// used for ActionCard TextInput type.
+	PotentialActionActionCardInputTextInputType = "TextInput"
+
+	// PotentialActionActionCardInputDateInputType is the type that must be
+	// used for ActionCard DateInput type.
+	PotentialActionActionCardInputDateInputType = "DateInput"
+
+	// PotentialActionActionCardInputMultichoiceInput is the type that must be
+	// used for ActionCard MultichoiceInput type.
+	PotentialActionActionCardInputMultichoiceInput = "MultichoiceInput"
+)
+
+// PotentialActionMaxSupported is the maximum number of actions allowed in a
+// MessageCardPotentialAction collection.
+// https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#actions
+const PotentialActionMaxSupported = 4
+
+// ErrPotentialActionsLimitReached indicates that the maximum supported number
+// of potentialAction collection values has been reached for either a
+// MessageCard or a MessageCardSection.
+var ErrPotentialActionsLimitReached = errors.New("potential actions collection limit reached")
+
+// MessageCardPotentialAction represents potential actions an user can do in a
+// message card. See
+// https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#actions
+// for more information.
+type MessageCardPotentialAction struct {
+	// Type of the potential action. Can be OpenUri, HttpPOST, ActionCard or
+	// InvokeAddInCommand.
+	Type string `json:"@type"`
+
+	// Name property defines the text that will be displayed on screen for the
+	// action.
+	Name string `json:"name"`
+
+	// MessageCardPotentialActionOpenURI is a set of options for openUri
+	// potential action.
+	MessageCardPotentialActionOpenURI
+
+	// MessageCardPotentialActionHTTPPOST is a set of options for httpPOST
+	// potential action.
+	MessageCardPotentialActionHTTPPOST
+
+	// MessageCardPotentialActionActionCard is a set of options for actionCard
+	// potential action.
+	MessageCardPotentialActionActionCard
+
+	// MessageCardPotentialActionInvokeAddInCommand is a set of options for
+	// invokeAddInCommand potential action.
+	MessageCardPotentialActionInvokeAddInCommand
+}
+
+// MessageCardPotentialActionOpenURI represents a OpenUri potential action.
+type MessageCardPotentialActionOpenURI struct {
+	// Targets is a collection of name/value pairs that defines one URI per
+	// target operating system. Only used for OpenUri action type.
+	Targets []MessageCardPotentialActionOpenURITarget `json:"targets,omitempty"`
+}
+
+// MessageCardPotentialActionHTTPPOST represents a HttpPOST potential action.
+type MessageCardPotentialActionHTTPPOST struct {
+	// Target defines the URL endpoint of the service that implements the
+	// action. Only used for HttpPOST action type.
+	Target string `json:"target,omitempty"`
+
+	// Headers is a collection of MessageCardPotentialActionHeader objects
+	// representing a set of HTTP headers that will be emitted when sending
+	// the POST request to the target URL. Only used for HttpPOST action type.
+	Headers []MessageCardPotentialActionHTTPPOSTHeader `json:"headers,omitempty"`
+
+	// Body is the body of the POST request. Only used for HttpPOST action
+	// type.
+	Body string `json:"body,omitempty"`
+
+	// BodyContentType is optional and specifies the MIME type of the body in
+	// the POST request. Only used for HttpPOST action type.
+	BodyContentType string `json:"bodyContentType,omitempty"`
+}
+
+// MessageCardPotentialActionActionCard represents an actionCard potential
+// action.
+type MessageCardPotentialActionActionCard struct {
+	// Inputs is a collection of inputs an user can provide before processing
+	// the actions. Only used for ActionCard action type. Three types of
+	// inputs are available: TextInput, DateInput and MultichoiceInput
+	Inputs []MessageCardPotentialActionActionCardInput `json:"inputs,omitempty"`
+
+	// Actions are the available actions. Only used for ActionCard action
+	// type.
+	Actions []MessageCardPotentialActionActionCardAction `json:"actions,omitempty"`
+}
+
+// MessageCardPotentialActionActionCardAction is used for configuring ActionCard actions
+type MessageCardPotentialActionActionCardAction struct {
+	// Type of the action. Can be OpenUri, HttpPOST, ActionCard or
+	// InvokeAddInCommand.
+	Type string `json:"@type"`
+
+	// Name property defines the text that will be displayed on screen for the
+	// action.
+	Name string `json:"name"`
+
+	// MessageCardPotentialActionOpenURI is used to specify a openUri action
+	// card's action.
+	MessageCardPotentialActionOpenURI
+
+	// MessageCardPotentialActionHTTPPOST is used to specify a httpPOST action
+	// card's action.
+	MessageCardPotentialActionHTTPPOST
+}
+
+// MessageCardPotentialActionInvokeAddInCommand represents an
+// invokeAddInCommand potential action.
+type MessageCardPotentialActionInvokeAddInCommand struct {
+	// AddInID specifies the add-in ID of the required add-in. Only used for
+	// InvokeAddInCommand action type.
+	AddInID string `json:"addInId,omitempty"`
+
+	// DesktopCommandID specifies the ID of the add-in command button that
+	// opens the required task pane. Only used for InvokeAddInCommand action
+	// type.
+	DesktopCommandID string `json:"desktopCommandId,omitempty"`
+
+	// InitializationContext is an optional field which provides developers a
+	// way to specify any valid JSON object. The value is serialized into a
+	// string and made available to the add-in when the action is executed.
+	// This allows the action to pass initialization data to the add-in. Only
+	// used for InvokeAddInCommand action type.
+	InitializationContext interface{} `json:"initializationContext,omitempty"`
+}
+
+// MessageCardPotentialActionOpenURITarget is used for OpenUri action type.
+// It defines one URI per target operating system.
+type MessageCardPotentialActionOpenURITarget struct {
+	// OS defines the operating system the target uri refers to. Supported
+	// operating system values are default, windows, iOS and android. The
+	// default operating system will in most cases simply open the URI in a
+	// web browser, regardless of the actual operating system.
+	OS string `json:"os,omitempty"`
+
+	// URI defines the URI being called.
+	URI string `json:"uri,omitempty"`
+}
+
+// MessageCardPotentialActionHTTPPOSTHeader defines a HTTP header used for HttpPOST action type.
+type MessageCardPotentialActionHTTPPOSTHeader struct {
+	// Name is the header name.
+	Name string `json:"name,omitempty"`
+
+	// Value is the header value.
+	Value string `json:"value,omitempty"`
+}
+
+// MessageCardPotentialActionActionCardInput represents an ActionCard input.
+type MessageCardPotentialActionActionCardInput struct {
+	// Type of the ActionCard input.
+	// Must be either TextInput, DateInput or MultichoiceInput
+	Type string `json:"@type"`
+
+	// ID uniquely identifies the input so it is possible to reference it in
+	// the URL or body of an HttpPOST action.
+	ID string `json:"id,omitempty"`
+
+	// Title defines a title for the input.
+	Title string `json:"title,omitempty"`
+
+	// Value defines the initial value of the input. For multi-choice inputs,
+	// value must be equal to the value property of one of the input's
+	// choices.
+	Value string `json:"value,omitempty"`
+
+	// MessageCardPotentialActionInputMultichoiceInput must be defined for
+	// MultichoiceInput input type.
+	MessageCardPotentialActionActionCardInputMultichoiceInput
+
+	// MessageCardPotentialActionInputTextInput must be defined for InputText
+	// input type.
+	MessageCardPotentialActionActionCardInputTextInput
+
+	// MessageCardPotentialActionInputDateInput must be defined for DateInput
+	// input type.
+	MessageCardPotentialActionActionCardInputDateInput
+
+	// IsRequired indicates whether users are required to type a value before
+	// they are able to take an action that would take the value of the input
+	// as a parameter.
+	IsRequired bool `json:"isRequired,omitempty"`
+}
+
+// MessageCardPotentialActionActionCardInputTextInput represents a TextInput
+// input used for potential action.
+type MessageCardPotentialActionActionCardInputTextInput struct {
+	// MaxLength indicates the maximum number of characters that can be
+	// entered.
+	MaxLength int `json:"maxLength,omitempty"`
+
+	// IsMultiline indicates whether the text input should accept multiple
+	// lines of text.
+	IsMultiline bool `json:"isMultiline,omitempty"`
+}
+
+// MessageCardPotentialActionActionCardInputMultichoiceInput represents a
+// MultichoiceInput input used for potential action.
+type MessageCardPotentialActionActionCardInputMultichoiceInput struct {
+	// Choices defines the values that can be selected for the multichoice
+	// input.
+	Choices []struct {
+		Display string `json:"display,omitempty"`
+		Value   string `json:"value,omitempty"`
+	} `json:"choices,omitempty"`
+
+	// Style defines the style of the input. When IsMultiSelect is false,
+	// setting the style property to expanded will instruct the host
+	// application to try and display all choices on the screen, typically
+	// using a set of radio buttons.
+	Style string `json:"style,omitempty"`
+
+	// IsMultiSelect indicates whether or not the user can select more than
+	// one choice. The specified choices will be displayed as a list of
+	// checkboxes. Default value is false.
+	IsMultiSelect bool `json:"isMultiSelect,omitempty"`
+}
+
+// MessageCardPotentialActionActionCardInputDateInput represents a DateInput
+// input used for potential action.
+type MessageCardPotentialActionActionCardInputDateInput struct {
+	// IncludeTime indicates whether the date input should allow for the
+	// selection of a time in addition to the date.
+	IncludeTime bool `json:"includeTime,omitempty"`
+}
+
+// MessageCardSectionFact represents a section fact entry that is usually
+// displayed in a two-column key/value format.
+type MessageCardSectionFact struct {
+
+	// Name is the key for an associated value in a key/value pair
+	Name string `json:"name"`
+
+	// Value is the value for an associated key in a key/value pair
+	Value string `json:"value"`
+}
+
+// MessageCardSectionImage represents an image as used by the heroImage and
+// images properties of a section.
+type MessageCardSectionImage struct {
+
+	// Image is the URL to the image.
+	Image string `json:"image"`
+
+	// Title is a short description of the image. Typically, this description
+	// is displayed in a tooltip as the user hovers their mouse over the
+	// image.
+	Title string `json:"title"`
+}
+
+// MessageCardSection represents a section to include in a message card.
+type MessageCardSection struct {
+	// Title is the title property of a section. This property is displayed
+	// in a font that stands out, while not as prominent as the card's title.
+	// It is meant to introduce the section and summarize its content,
+	// similarly to how the card's title property is meant to summarize the
+	// whole card.
+	Title string `json:"title,omitempty"`
+
+	// Text is the section's text property. This property is very similar to
+	// the text property of the card. It can be used for the same purpose.
+	Text string `json:"text,omitempty"`
+
+	// ActivityImage is a property used to display a picture associated with
+	// the subject of a message card. For example, this might be the portrait
+	// of a person who performed an activity that the message card is
+	// associated with.
+	ActivityImage string `json:"activityImage,omitempty"`
+
+	// ActivityTitle is a property used to summarize the activity associated
+	// with a message card.
+	ActivityTitle string `json:"activityTitle,omitempty"`
+
+	// ActivitySubtitle is a property used to show brief, but extended
+	// information about an activity associated with a message card. Examples
+	// include the date and time the associated activity was taken or the
+	// handle of a person associated with the activity.
+	ActivitySubtitle string `json:"activitySubtitle,omitempty"`
+
+	// ActivityText is a property used to provide details about the activity.
+	// For example, if the message card is used to deliver updates about a
+	// topic, then this property would be used to hold the bulk of the content
+	// for the update notification.
+	ActivityText string `json:"activityText,omitempty"`
+
+	// HeroImage is a property that allows for setting an image as the
+	// centerpiece of a message card. This property can also be used to add a
+	// banner to the message card.
+	// Note: heroImage is not currently supported by Microsoft Teams
+	// https://stackoverflow.com/a/45389789
+	// We use a pointer to this type in order to have the json package
+	// properly omit this field if not explicitly set.
+	// https://github.com/golang/go/issues/11939
+	// https://stackoverflow.com/questions/18088294/how-to-not-marshal-an-empty-struct-into-json-with-go
+	// https://stackoverflow.com/questions/33447334/golang-json-marshal-how-to-omit-empty-nested-struct
+	HeroImage *MessageCardSectionImage `json:"heroImage,omitempty"`
+
+	// Facts is a collection of MessageCardSectionFact values. A section entry
+	// usually is displayed in a two-column key/value format.
+	Facts []MessageCardSectionFact `json:"facts,omitempty"`
+
+	// Images is a property that allows for the inclusion of a photo gallery
+	// inside a section.
+	// We use a slice of pointers to this type in order to have the json
+	// package properly omit this field if not explicitly set.
+	// https://github.com/golang/go/issues/11939
+	// https://stackoverflow.com/questions/18088294/how-to-not-marshal-an-empty-struct-into-json-with-go
+	// https://stackoverflow.com/questions/33447334/golang-json-marshal-how-to-omit-empty-nested-struct
+	Images []*MessageCardSectionImage `json:"images,omitempty"`
+
+	// PotentialActions is a collection of actions for a MessageCardSection.
+	// This is separate from the actions collection for the MessageCard.
+	PotentialActions []*MessageCardPotentialAction `json:"potentialAction,omitempty"`
+
+	// Markdown represents a toggle to enable or disable Markdown formatting.
+	// By default, all text fields in a card and its sections can be formatted
+	// using basic Markdown.
+	Markdown bool `json:"markdown,omitempty"`
+
+	// StartGroup is the section's startGroup property. This property marks
+	// the start of a logical group of information. Typically, sections with
+	// startGroup set to true will be visually separated from previous card
+	// elements.
+	StartGroup bool `json:"startGroup,omitempty"`
+}
+
+// MessageCard represents a legacy actionable message card used via Office 365
+// or Microsoft Teams connectors.
+type MessageCard struct {
+	// Required; must be set to "MessageCard"
+	Type string `json:"@type"`
+
+	// Required; must be set to "https://schema.org/extensions"
+	Context string `json:"@context"`
+
+	// Summary is required if the card does not contain a text property,
+	// otherwise optional. The summary property is typically displayed in the
+	// list view in Outlook, as a way to quickly determine what the card is
+	// all about. Summary appears to only be used when there are sections defined
+	Summary string `json:"summary,omitempty"`
+
+	// Title is the title property of a card. is meant to be rendered in a
+	// prominent way, at the very top of the card. Use it to introduce the
+	// content of the card in such a way users will immediately know what to
+	// expect.
+	Title string `json:"title,omitempty"`
+
+	// Text is required if the card does not contain a summary property,
+	// otherwise optional. The text property is meant to be displayed in a
+	// normal font below the card's title. Use it to display content, such as
+	// the description of the entity being referenced, or an abstract of a
+	// news article.
+	Text string `json:"text,omitempty"`
+
+	// Specifies a custom brand color for the card. The color will be
+	// displayed in a non-obtrusive manner.
+	ThemeColor string `json:"themeColor,omitempty"`
+
+	// ValidateFunc is a validation function that validates a MessageCard
+	ValidateFunc func() error `json:"-"`
+
+	// Sections is a collection of sections to include in the card.
+	Sections []*MessageCardSection `json:"sections,omitempty"`
+
+	// PotentialActions is a collection of actions for a MessageCard.
+	PotentialActions []*MessageCardPotentialAction `json:"potentialAction,omitempty"`
+}
+
+// validatePotentialAction inspects the given *MessageCardPotentialAction
+// and returns an error if a value is missing or not known.
+func validatePotentialAction(pa *MessageCardPotentialAction) error {
+	if pa == nil {
+		return fmt.Errorf("nil MessageCardPotentialAction received")
+	}
+
+	switch pa.Type {
+	case PotentialActionOpenURIType,
+		PotentialActionHTTPPostType,
+		PotentialActionActionCardType,
+		PotentialActionInvokeAddInCommandType:
+
+	default:
+		return fmt.Errorf("unknown type %s for potential action %s", pa.Type, pa.Name)
+	}
+
+	if pa.Name == "" {
+		return fmt.Errorf("missing name value for MessageCardPotentialAction")
+	}
+
+	return nil
+}
+
+// addPotentialAction adds one or many MessageCardPotentialAction values to a
+// PotentialActions collection.
+func addPotentialAction(collection *[]*MessageCardPotentialAction, actions ...*MessageCardPotentialAction) error {
+	for _, a := range actions {
+		logger.Printf("addPotentialAction: MessageCardPotentialAction received: %+v\n", a)
+
+		if err := validatePotentialAction(a); err != nil {
+			logger.Printf("addPotentialAction: validation failed: %v", err)
+
+			return err
+		}
+
+		if len(*collection) > PotentialActionMaxSupported {
+			logger.Printf("addPotentialAction: failed to add potential action: %v", ErrPotentialActionsLimitReached.Error())
+
+			return fmt.Errorf("func addPotentialAction: failed to add potential action: %w", ErrPotentialActionsLimitReached)
+		}
+
+		*collection = append(*collection, a)
+	}
+
+	return nil
+}
+
+// AddSection adds one or many additional MessageCardSection values to a
+// MessageCard. Validation is performed to reject invalid values with an error
+// message.
+func (mc *MessageCard) AddSection(section ...*MessageCardSection) error {
+	for _, s := range section {
+		logger.Printf("AddSection: MessageCardSection received: %+v\n", s)
+
+		// bail if a completely nil section provided
+		if s == nil {
+			return fmt.Errorf("func AddSection: nil MessageCardSection received")
+		}
+
+		// Perform validation of all MessageCardSection fields in an effort to
+		// avoid adding a MessageCardSection with zero value fields. This is
+		// done to avoid generating an empty sections JSON array since the
+		// Sections slice for the MessageCard type would technically not be at
+		// a zero value state. Due to this non-zero value state, the
+		// encoding/json package would end up including the Sections struct
+		// field in the output JSON.
+		// See also https://github.com/golang/go/issues/11939
+		switch {
+		// If any of these cases trigger, skip over the `default` case
+		// statement and add the section.
+		case s.Images != nil:
+		case s.Facts != nil:
+		case s.HeroImage != nil:
+		case s.StartGroup:
+		case s.Markdown:
+		case s.ActivityText != "":
+		case s.ActivitySubtitle != "":
+		case s.ActivityTitle != "":
+		case s.ActivityImage != "":
+		case s.Text != "":
+		case s.Title != "":
+
+		default:
+			logger.Println("AddSection: No cases matched, all fields assumed to be at zero-value, skipping section")
+			return fmt.Errorf("all fields found to be at zero-value, skipping section")
+		}
+
+		logger.Println("AddSection: section contains at least one non-zero value, adding section")
+		mc.Sections = append(mc.Sections, s)
+	}
+
+	return nil
+}
+
+// AddPotentialAction adds one or many MessageCardPotentialAction values to a
+// PotentialActions collection on a MessageCard.
+func (mc *MessageCard) AddPotentialAction(actions ...*MessageCardPotentialAction) error {
+	return addPotentialAction(&mc.PotentialActions, actions...)
+}
+
+// Validate validates a MessageCard calling ValidateFunc if defined,
+// otherwise, a default validation occurs
+func (mc *MessageCard) Validate() error {
+	if mc.ValidateFunc != nil {
+		return mc.ValidateFunc()
+	}
+
+	// Falling back to a default implementation
+	if (mc.Text == "") && (mc.Summary == "") {
+		// This scenario results in:
+		// 400 Bad Request
+		// Summary or Text is required.
+		return fmt.Errorf("invalid message card: summary or text field is required")
+	}
+
+	return nil
+}
+
+// AddFact adds one or many additional MessageCardSectionFact values to a
+// MessageCardSection
+func (mcs *MessageCardSection) AddFact(fact ...MessageCardSectionFact) error {
+	for _, f := range fact {
+		logger.Printf("AddFact: MessageCardSectionFact received: %+v\n", f)
+
+		if f.Name == "" {
+			return fmt.Errorf("empty Name field received for new fact: %+v", f)
+		}
+
+		if f.Value == "" {
+			return fmt.Errorf("empty Name field received for new fact: %+v", f)
+		}
+	}
+
+	logger.Println("AddFact: section fact contains at least one non-zero value, adding section fact")
+	mcs.Facts = append(mcs.Facts, fact...)
+
+	return nil
+}
+
+// AddFactFromKeyValue accepts a key and slice of values and converts them to
+// MessageCardSectionFact values
+func (mcs *MessageCardSection) AddFactFromKeyValue(key string, values ...string) error {
+	// validate arguments
+
+	if key == "" {
+		return errors.New("empty key received for new fact")
+	}
+
+	if len(values) < 1 {
+		return errors.New("no values received for new fact")
+	}
+
+	fact := MessageCardSectionFact{
+		Name:  key,
+		Value: strings.Join(values, ", "),
+	}
+	// TODO: Explicitly define or use constructor?
+	// fact := NewMessageCardSectionFact()
+	// fact.Name = key
+	// fact.Value = strings.Join(values, ", ")
+
+	mcs.Facts = append(mcs.Facts, fact)
+
+	// if we made it this far then all should be well
+	return nil
+}
+
+// AddPotentialAction adds one or many MessageCardPotentialAction values to a
+// PotentialActions collection on a MessageCardSection. This is separate from
+// the actions collection for the MessageCard.
+func (mcs *MessageCardSection) AddPotentialAction(actions ...*MessageCardPotentialAction) error {
+	return addPotentialAction(&mcs.PotentialActions, actions...)
+}
+
+// AddImage adds an image to a MessageCard section. These images are used to
+// provide a photo gallery inside a MessageCard section.
+func (mcs *MessageCardSection) AddImage(sectionImage ...MessageCardSectionImage) error {
+	for i := range sectionImage {
+		if sectionImage[i].Image == "" {
+			return fmt.Errorf("cannot add empty image URL")
+		}
+
+		if sectionImage[i].Title == "" {
+			return fmt.Errorf("cannot add empty image title")
+		}
+
+		mcs.Images = append(mcs.Images, &sectionImage[i])
+	}
+
+	return nil
+}
+
+// AddHeroImageStr adds a Hero Image to a MessageCard section using string
+// arguments. This image is used as the centerpiece or banner of a message
+// card.
+func (mcs *MessageCardSection) AddHeroImageStr(imageURL string, imageTitle string) error {
+	if imageURL == "" {
+		return fmt.Errorf("cannot add empty hero image URL")
+	}
+
+	if imageTitle == "" {
+		return fmt.Errorf("cannot add empty hero image title")
+	}
+
+	heroImage := MessageCardSectionImage{
+		Image: imageURL,
+		Title: imageTitle,
+	}
+	// TODO: Explicitly define or use constructor?
+	// heroImage := NewMessageCardSectionImage()
+	// heroImage.Image = imageURL
+	// heroImage.Title = imageTitle
+
+	mcs.HeroImage = &heroImage
+
+	// our validation checks didn't find any problems
+	return nil
+}
+
+// AddHeroImage adds a Hero Image to a MessageCard section using a
+// MessageCardSectionImage argument. This image is used as the centerpiece or
+// banner of a message card.
+func (mcs *MessageCardSection) AddHeroImage(heroImage MessageCardSectionImage) error {
+	if heroImage.Image == "" {
+		return fmt.Errorf("cannot add empty hero image URL")
+	}
+
+	if heroImage.Title == "" {
+		return fmt.Errorf("cannot add empty hero image title")
+	}
+
+	mcs.HeroImage = &heroImage
+
+	// our validation checks didn't find any problems
+	return nil
+}
+
+// NewMessageCard creates a new message card with fields required by the
+// legacy message card format already predefined
+func NewMessageCard() MessageCard {
+	// define expected values to meet Office 365 Connector card requirements
+	// https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference#card-fields
+	msgCard := MessageCard{
+		Type:    "MessageCard",
+		Context: "https://schema.org/extensions",
+	}
+
+	return msgCard
+}
+
+// NewMessageCardSection creates an empty message card section
+func NewMessageCardSection() *MessageCardSection {
+	msgCardSection := MessageCardSection{}
+	return &msgCardSection
+}
+
+// NewMessageCardSectionFact creates an empty message card section fact
+func NewMessageCardSectionFact() MessageCardSectionFact {
+	msgCardSectionFact := MessageCardSectionFact{}
+	return msgCardSectionFact
+}
+
+// NewMessageCardSectionImage creates an empty image for use with message card
+// section
+func NewMessageCardSectionImage() MessageCardSectionImage {
+	msgCardSectionImage := MessageCardSectionImage{}
+	return msgCardSectionImage
+}
+
+// NewMessageCardPotentialAction creates a new MessageCardPotentialAction
+// using the provided potential action type and name. The name values defines
+// the text that will be displayed on screen for the action. An error is
+// returned if invalid values are supplied.
+func NewMessageCardPotentialAction(potentialActionType string, name string) (*MessageCardPotentialAction, error) {
+	pa := MessageCardPotentialAction{
+		Type: potentialActionType,
+		Name: name,
+	}
+
+	if err := validatePotentialAction(&pa); err != nil {
+		return nil, err
+	}
+
+	return &pa, nil
+}

--- a/vendor/github.com/atc0005/go-teams-notify/v2/send.go
+++ b/vendor/github.com/atc0005/go-teams-notify/v2/send.go
@@ -1,0 +1,408 @@
+// Copyright 2020 Enrico Hoffmann
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/go-teams-notify
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package goteamsnotify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// logger is a package logger that can be enabled from client code to allow
+// logging output from this package when desired/needed for troubleshooting
+var logger *log.Logger
+
+// Known webhook URL prefixes for submitting messages to Microsoft Teams
+const (
+	WebhookURLOfficecomPrefix  = "https://outlook.office.com"
+	WebhookURLOffice365Prefix  = "https://outlook.office365.com"
+	WebhookURLOrgWebhookPrefix = "https://example.webhook.office.com"
+)
+
+// DisableWebhookURLValidation is a special keyword used to indicate to
+// validation function(s) that webhook URL validation should be disabled.
+//
+// Deprecated: prefer using API.SkipWebhookURLValidationOnSend(bool) method instead
+const DisableWebhookURLValidation string = "DISABLE_WEBHOOK_URL_VALIDATION"
+
+// Regular Expression related constants that we can use to validate incoming
+// webhook URLs provided by the user.
+const (
+
+	// DefaultWebhookURLValidationPattern is a minimal regex for matching known valid
+	// webhook URL prefix patterns.
+	DefaultWebhookURLValidationPattern = `^https:\/\/(?:.*\.webhook|outlook)\.office(?:365)?\.com`
+
+	// Note: The regex allows for capital letters in the GUID patterns. This is
+	// allowed based on light testing which shows that mixed case works and the
+	// assumption that since Teams and Office 365 are Microsoft products case
+	// would be ignored (e.g., Windows, IIS do not consider 'A' and 'a' to be
+	// different).
+	// webhookURLRegex           = `^https:\/\/(?:.*\.webhook|outlook)\.office(?:365)?\.com\/webhook(?:b2)?\/[-a-zA-Z0-9]{36}@[-a-zA-Z0-9]{36}\/IncomingWebhook\/[-a-zA-Z0-9]{32}\/[-a-zA-Z0-9]{36}$`
+
+	// webhookURLSubURIWebhookPrefix         = "webhook"
+	// webhookURLSubURIWebhookb2Prefix       = "webhookb2"
+	// webhookURLOfficialDocsSampleURI       = "a1269812-6d10-44b1-abc5-b84f93580ba0@9e7b80c7-d1eb-4b52-8582-76f921e416d9/IncomingWebhook/3fdd6767bae44ac58e5995547d66a4e4/f332c8d9-3397-4ac5-957b-b8e3fc465a8c"
+)
+
+// ExpectedWebhookURLResponseText represents the expected response text
+// provided by the remote webhook endpoint when submitting messages.
+const ExpectedWebhookURLResponseText string = "1"
+
+// DefaultWebhookSendTimeout specifies how long the message operation may take
+// before it times out and is cancelled.
+const DefaultWebhookSendTimeout = 5 * time.Second
+
+// ErrWebhookURLUnexpected is returned when a provided webhook URL does
+// not match a set of confirmed webhook URL patterns.
+var ErrWebhookURLUnexpected = errors.New("webhook URL does not match one of expected patterns")
+
+// ErrWebhookURLUnexpectedPrefix is returned when a provided webhook URL does
+// not match a set of confirmed webhook URL prefixes.
+//
+// Deprecated: Use ErrWebhookURLUnexpected instead.
+var ErrWebhookURLUnexpectedPrefix = ErrWebhookURLUnexpected
+
+// ErrInvalidWebhookURLResponseText is returned when the remote webhook
+// endpoint indicates via response text that a message submission was
+// unsuccessful.
+var ErrInvalidWebhookURLResponseText = errors.New("invalid webhook URL response text")
+
+// API - interface of MS Teams notify
+type API interface {
+	Send(webhookURL string, webhookMessage MessageCard) error
+	SendWithContext(ctx context.Context, webhookURL string, webhookMessage MessageCard) error
+	SendWithRetry(ctx context.Context, webhookURL string, webhookMessage MessageCard, retries int, retriesDelay int) error
+	SkipWebhookURLValidationOnSend(skip bool) API
+	AddWebhookURLValidationPatterns(patterns ...string) API
+	ValidateWebhook(webhookURL string) error
+}
+
+type teamsClient struct {
+	httpClient                   *http.Client
+	webhookURLValidationPatterns []string
+	skipWebhookURLValidation     bool
+}
+
+func init() {
+	// Disable logging output by default unless client code explicitly
+	// requests it
+	logger = log.New(os.Stderr, "[goteamsnotify] ", 0)
+	logger.SetOutput(ioutil.Discard)
+}
+
+// EnableLogging enables logging output from this package. Output is muted by
+// default unless explicitly requested (by calling this function).
+func EnableLogging() {
+	logger.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	logger.SetOutput(os.Stderr)
+}
+
+// DisableLogging reapplies default package-level logging settings of muting
+// all logging output.
+func DisableLogging() {
+	logger.SetFlags(0)
+	logger.SetOutput(ioutil.Discard)
+}
+
+// NewClient - create a brand new client for MS Teams notify
+func NewClient() API {
+	client := teamsClient{
+		httpClient: &http.Client{
+			// We're using a context instead of setting this directly
+			// Timeout: DefaultWebhookSendTimeout,
+		},
+		skipWebhookURLValidation: false,
+	}
+	return &client
+}
+
+func (c *teamsClient) AddWebhookURLValidationPatterns(patterns ...string) API {
+	c.webhookURLValidationPatterns = append(c.webhookURLValidationPatterns, patterns...)
+	return c
+}
+
+// Send is a wrapper function around the SendWithContext method in order to
+// provide backwards compatibility.
+func (c teamsClient) Send(webhookURL string, webhookMessage MessageCard) error {
+	// Create context that can be used to emulate existing timeout behavior.
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultWebhookSendTimeout)
+	defer cancel()
+
+	return c.SendWithContext(ctx, webhookURL, webhookMessage)
+}
+
+// SendWithContext posts a notification to the provided MS Teams webhook URL.
+// The http client request honors the cancellation or timeout of the provided
+// context.
+func (c teamsClient) SendWithContext(ctx context.Context, webhookURL string, webhookMessage MessageCard) error {
+	logger.Printf("SendWithContext: Webhook message received: %#v\n", webhookMessage)
+
+	// optionally skip webhook validation
+	if c.skipWebhookURLValidation {
+		logger.Printf("SendWithContext: Webhook URL will not be validated: %#v\n", webhookURL)
+	}
+
+	// Validate input data
+	if err := c.validateInput(webhookMessage, webhookURL); err != nil {
+		return err
+	}
+
+	// prepare message
+	webhookMessageByte, _ := json.Marshal(webhookMessage)
+	webhookMessageBuffer := bytes.NewBuffer(webhookMessageByte)
+
+	// Basic, unformatted JSON
+	// logger.Printf("SendWithContext: %+v\n", string(webhookMessageByte))
+
+	var prettyJSON bytes.Buffer
+	if err := json.Indent(&prettyJSON, webhookMessageByte, "", "\t"); err != nil {
+		return err
+	}
+	logger.Printf("SendWithContext: Payload for Microsoft Teams: \n\n%v\n\n", prettyJSON.String())
+
+	// prepare request (error not possible)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, webhookMessageBuffer)
+	req.Header.Add("Content-Type", "application/json;charset=utf-8")
+
+	// do the request
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		logger.Println(err)
+		return err
+	}
+
+	if ctx.Err() != nil {
+		logger.Println("SendWithContext: Context has expired after Do(req):", time.Now().Format("15:04:05"))
+	}
+
+	// Make sure that we close the response body once we're done with it
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			log.Printf("error closing response body: %v", err)
+		}
+	}()
+
+	// Get the response body, then convert to string for use with extended
+	// error messages
+	responseData, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		logger.Println(err)
+		return err
+	}
+	responseString := string(responseData)
+
+	switch {
+	// 400 Bad Response is likely an indicator that we failed to provide a
+	// required field in our JSON payload. For example, when leaving out the
+	// top level MessageCard Summary or Text field, the remote API returns
+	// "Summary or Text is required." as a text string. We include that
+	// response text in the error message that we return to the caller.
+	case res.StatusCode >= 299:
+		err = fmt.Errorf("error on notification: %v, %q", res.Status, responseString)
+		logger.Println(err)
+		return err
+
+	// Microsoft Teams developers have indicated that a 200 status code is
+	// insufficient to confirm that a message was successfully submitted.
+	// Instead, clients should ensure that a specific response string was also
+	// returned along with a 200 status code to confirm that a message was
+	// sent successfully. Because there is a chance that unintentional
+	// whitespace could be included, we explicitly strip it out.
+	//
+	// See atc0005/go-teams-notify#59 for more information.
+	case responseString != strings.TrimSpace(ExpectedWebhookURLResponseText):
+
+		err = fmt.Errorf(
+			"got %q, expected %q: %w",
+			responseString,
+			ExpectedWebhookURLResponseText,
+			ErrInvalidWebhookURLResponseText,
+		)
+
+		logger.Println(err)
+		return err
+
+	default:
+
+		// log the response string
+		logger.Printf("SendWithContext: Response string from Microsoft Teams API: %v\n", responseString)
+
+		return nil
+	}
+}
+
+// SendWithRetry is a wrapper function around the SendWithContext method in
+// order to provide message retry support. The caller is responsible for
+// provided the desired context timeout, the number of retries and retries
+// delay.
+func (c teamsClient) SendWithRetry(ctx context.Context, webhookURL string, webhookMessage MessageCard, retries int, retriesDelay int) error {
+	var result error
+
+	// initial attempt + number of specified retries
+	attemptsAllowed := 1 + retries
+
+	// attempt to send message to Microsoft Teams, retry specified number of
+	// times before giving up
+	for attempt := 1; attempt <= attemptsAllowed; attempt++ {
+		// the result from the last attempt is returned to the caller
+		result = c.SendWithContext(ctx, webhookURL, webhookMessage)
+
+		switch {
+		case result == nil:
+
+			logger.Printf(
+				"SendWithRetry: successfully sent message after %d of %d attempts\n",
+				attempt,
+				attemptsAllowed,
+			)
+
+			// No further retries needed
+			return nil
+
+		// While the context is passed to mstClient.SendWithContext and it
+		// should ensure that it is respected, we check here explicitly in
+		// order to return early in an effort to prevent undesired message
+		// attempts
+		case ctx.Err() != nil && result != nil:
+
+			errMsg := fmt.Errorf(
+				"SendWithRetry: context cancelled or expired: %v; "+
+					"aborting message submission after %d of %d attempts: %w",
+				ctx.Err().Error(),
+				attempt,
+				attemptsAllowed,
+				result,
+			)
+
+			logger.Println(errMsg)
+			return errMsg
+
+		case result != nil:
+
+			ourRetryDelay := time.Duration(retriesDelay) * time.Second
+
+			logger.Printf(
+				"SendWithRetry: Attempt %d of %d to send message failed: %v",
+				attempt,
+				attemptsAllowed,
+				result,
+			)
+
+			// apply retry delay since our context hasn't been cancelled yet,
+			// otherwise continue with the loop to allow context cancellation
+			// handling logic to be applied
+			logger.Printf(
+				"SendWithRetry: Context not cancelled yet, applying retry delay of %v",
+				ourRetryDelay,
+			)
+			time.Sleep(ourRetryDelay)
+		}
+	}
+
+	return result
+}
+
+// SkipWebhookURLValidationOnSend allows the caller to optionally disable
+// webhook URL validation.
+func (c *teamsClient) SkipWebhookURLValidationOnSend(skip bool) API {
+	c.skipWebhookURLValidation = skip
+	return c
+}
+
+// validateInput verifies if the input parameters are valid
+func (c teamsClient) validateInput(webhookMessage MessageCard, webhookURL string) error {
+	// validate url
+	if err := c.ValidateWebhook(webhookURL); err != nil {
+		return err
+	}
+
+	// validate message
+	return webhookMessage.Validate()
+}
+
+func (c teamsClient) ValidateWebhook(webhookURL string) error {
+	if c.skipWebhookURLValidation || webhookURL == DisableWebhookURLValidation {
+		return nil
+	}
+
+	u, err := url.Parse(webhookURL)
+	if err != nil {
+		return fmt.Errorf("unable to parse webhook URL %q: %w", webhookURL, err)
+	}
+
+	patterns := c.webhookURLValidationPatterns
+	if len(patterns) == 0 {
+		patterns = []string{DefaultWebhookURLValidationPattern}
+	}
+
+	// Return true if at least one pattern matches
+	for _, pat := range patterns {
+		matched, err := regexp.MatchString(pat, webhookURL)
+		if err != nil {
+			return err
+		}
+		if matched {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%w; got: %q, patterns: %s", ErrWebhookURLUnexpected, u.String(), strings.Join(patterns, ","))
+}
+
+// old deprecated helper functions --------------------------------------------------------------------------------------------------------------
+
+// IsValidInput is a validation "wrapper" function. This function is intended
+// to run current validation checks and offer easy extensibility for future
+// validation requirements.
+//
+// Deprecated: use API.ValidateWebhook() and MessageCard.Validate()
+// methods instead.
+func IsValidInput(webhookMessage MessageCard, webhookURL string) (bool, error) {
+	// validate url
+	if valid, err := IsValidWebhookURL(webhookURL); !valid {
+		return false, err
+	}
+
+	// validate message
+	if valid, err := IsValidMessageCard(webhookMessage); !valid {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// IsValidWebhookURL performs validation checks on the webhook URL used to
+// submit messages to Microsoft Teams.
+//
+// Deprecated: use API.ValidateWebhook() method instead.
+func IsValidWebhookURL(webhookURL string) (bool, error) {
+	c := teamsClient{}
+	err := c.ValidateWebhook(webhookURL)
+	return err == nil, err
+}
+
+// IsValidMessageCard performs validation/checks for known issues with
+// MessardCard values.
+//
+// Deprecated: use MessageCard.Validate() instead.
+func IsValidMessageCard(webhookMessage MessageCard) (bool, error) {
+	err := webhookMessage.Validate()
+	return err == nil, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,6 @@
+# github.com/atc0005/go-teams-notify/v2 v2.6.0
+## explicit
+github.com/atc0005/go-teams-notify/v2
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
 # github.com/cespare/xxhash/v2 v2.1.1
@@ -91,8 +94,6 @@ github.com/robfig/cron
 # github.com/sirupsen/logrus v1.8.1
 ## explicit
 github.com/sirupsen/logrus
-# github.com/stretchr/testify v1.6.1
-## explicit
 # github.com/valyala/bytebufferpool v1.0.0
 github.com/valyala/bytebufferpool
 # github.com/valyala/fasttemplate v1.2.1


### PR DESCRIPTION
This feature adds support for Microsoft Teams notifications by specifying a webhook URL:
![image](https://user-images.githubusercontent.com/4939519/125653794-3ad539e7-7bbc-48d8-a7b8-e79b2ce61d09.png)


In addition to the main PR change, the `vendor` folder has been removed, @JamesClonk we can maybe discuss if it makes sense to keep the directory but IMHO it is useless unless we provide some specific patch or something.

Currently the notifications are only supported for the _backup operation_ and for _Microsoft Teams_ as a target. In the future we might extend this to other targets (e.g: OpsGenie for when the backups fail) and include support for Restore notifications, as well as a fine-grained tuning of the notifications.