### PR TITLE
Update MongoDB tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,12 @@ RUN echo "debconf debconf/frontend select noninteractive" | debconf-set-selectio
   apt-get -y $package_args install curl ca-certificates gnupg tzdata
 
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-  curl https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add - && \
+  curl https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add - && \
   echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
-  echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.4 multiverse" > /etc/apt/sources.list.d/mongodb-org-4.4.list
+  echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/5.0 multiverse" > /etc/apt/sources.list.d/mongodb-org-4.4.list
 RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash -
 RUN apt-get -y $package_args update && \
-  apt-get -y $package_args install mysql-client postgresql-client-12 mongodb-org-tools=4.4.5 mongodb-org-shell=4.4.5 redis-tools nodejs openssh-server bash vim && \
+  apt-get -y $package_args install mysql-client postgresql-client-12 mongodb-database-tools=100.4.1 mongodb-org-shell=5.0.2 redis-tools nodejs openssh-server bash vim && \
   apt-get clean && \
   find /usr/share/doc/*/* ! -name copyright | xargs rm -rf && \
   rm -rf \

--- a/apt.yml
+++ b/apt.yml
@@ -1,13 +1,13 @@
 ---
 keys:
 - https://www.postgresql.org/media/keys/ACCC4CF8.asc
-- https://www.mongodb.org/static/pgp/server-4.4.asc
+- https://www.mongodb.org/static/pgp/server-5.0.asc
 repos:
 - deb https://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main
-- deb https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.4 multiverse
+- deb https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/5.0 multiverse
 packages:
 - mysql-client
 - postgresql-client-12
-- mongodb-org-tools=4.4.0
-- mongodb-org-shell=4.4.0
+- mongodb-database-tools=100.4.1
+- mongodb-org-shell=5.0.2
 - redis-tools


### PR DESCRIPTION
As mentioned in #37 there are some other vulnerabilities caused by an the inclusion of a version of MongoDB tools, which in turn did not update their dependency on a vulnerable MongoDB Go-Driver:
MongoDB 100.4.0 includes the new GoDriver 1.6.

Upgrading this dependency should hopefully eliminate the appearance of CVE-2020-28852, CVE-2020-29652 for backman in Vulnerability reports.

But the new MongoDB driver is now included in the tools from 100.4.0 and above. [See release notes](https://docs.mongodb.com/database-tools/release-notes/database-tools-changelog/#100.4.0-changelog)

(I'm checking if another, separate, request should be done to include the newest Go version as well to eliminate further vulnerabilities)