### PR TITLE
Security: Update NPM to newer version than initial bundled nodejs version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get -y $package_args update && \
   rm -rf \
   /usr/share/man/* /usr/share/info/* \
   /var/lib/apt/lists/* /tmp/*
-RUN npm install elasticdump -g
+RUN npm install -g npm elasticdump
 
 RUN mongorestore --version
 


### PR DESCRIPTION
This PR updates the NPM version installed during the NodeJS installations to the newest compatible version.

In my testing this shows as a version jump from 6.14.15 to 8.1.2 (`npm version`).

According to a scan result when building this, this resolved the following vulnerabilities from the original npm version:
- CVE-2021-27290 (in ssri; see also https://snyk.io/vuln/SNYK-JS-SSRI-1085630, disputed)
- GHSA-pc5p-h8pf-mvwp (in https-proxy-agent, https://github.com/advisories/GHSA-pc5p-h8pf-mvwp )