### PR TITLE
New flag "disable_restore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ backman-app
 backman
 /tmp
 _fixtures/*
+/.idea/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ These here are the default values backman will use if not configured via JSON:
 	"logging_timestamp": false,
 	"disable_web": false,
 	"disable_metrics": false,
+	"disable_restore": false,
 	"unprotected_metrics": false,
 	"notifications": {
 		"teams": {
@@ -88,6 +89,7 @@ Possible JSON properties:
 - `password`: optional, HTTP basic auth password
 - `disable_web`: optional, disable web interface and api
 - `disable_metrics`: optional, disable Prometheus metrics endpoint
+- `disable_restore`: optional, disable restore function on API and web. It can be used to mitigate damage in case backman credentials are leaked. Enable it just before you might need to restore.
 - `unprotected_metrics`: optional, disable HTTP basic auth protection for Prometheus metrics endpoint
 - `notifications.teams.webhook`: optional, setting a webhook URL will enable MS Teams notifications about backups
 - `notifications.teams.events`: optional, list of events to send a Teams notification for. Can be *backup-started*, *backup-success*, *backup-failed*. Sends a notification for all events if empty.

--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
 	"logging_timestamp": false,
 	"disable_web": false,
 	"disable_metrics": false,
+	"disable_restore": false,
 	"unprotected_metrics": false,
 	"username": "http_basic_auth_user_abc",
 	"password": "http_basic_auth_password_xyz",

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Password           string
 	DisableWeb         bool               `json:"disable_web"`
 	DisableMetrics     bool               `json:"disable_metrics"`
+	DisableRestore     bool               `json:"disable_restore"`
 	UnprotectedMetrics bool               `json:"unprotected_metrics"`
 	Notifications      NotificationConfig `json:"notifications"`
 	S3                 S3Config
@@ -141,6 +142,9 @@ func Get() *Config {
 			}
 			if envConfig.DisableMetrics {
 				config.DisableMetrics = envConfig.DisableMetrics
+			}
+			if envConfig.DisableRestore {
+				config.DisableRestore = envConfig.DisableRestore
 			}
 			if envConfig.UnprotectedMetrics {
 				config.UnprotectedMetrics = envConfig.UnprotectedMetrics

--- a/public/service.html
+++ b/public/service.html
@@ -100,10 +100,14 @@
 										<i class="icon icon-024-download-cloud" aria-hidden="true"></i>
 										<span class="toolbar__label"><small>Download</small></span>
 									</button>
-									{{ if not (eq (ServiceType .Service.Label).String "Redis") }}<button class="toolbar__item item--show padding-v-0 restore-button" aria-label="Restore" v-on:click="showRestoreDialog(file.Filename)">
-										<i class="icon icon-delivery-2" aria-hidden="true"></i>
-										<span class="toolbar__label"><small>Restore</small></span>
-									</button>{{ end }}
+									{{ if not (eq (ServiceType .Service.Label).String "Redis") }}
+										{{ if not Config.DisableRestore }}
+											<button class="toolbar__item item--show padding-v-0 restore-button" aria-label="Restore" v-on:click="showRestoreDialog(file.Filename)">
+												<i class="icon icon-delivery-2" aria-hidden="true"></i>
+												<span class="toolbar__label"><small>Restore</small></span>
+											</button>
+										{{ end }}
+									{{ end }}
 									<button class="toolbar__item item--show padding-v-0 delete-button" aria-label="Delete" v-on:click="showDeleteDialog(file.Filename)">
 										<i class="icon icon-008-bin" aria-hidden="true"></i>
 										<span class="toolbar__label"><small>Delete</small></span>

--- a/router/api/handler.go
+++ b/router/api/handler.go
@@ -53,8 +53,10 @@ func (h *Handler) RegisterRoutes(e *echo.Echo) {
 	g.POST("/backup/:service_type/:service_name", h.CreateBackup)
 	g.DELETE("/backup/:service_type/:service_name/:file", h.DeleteBackup)
 
-	g.POST("/restore/:service_type/:service_name/:file", h.RestoreBackup)
-	g.POST("/restore/:service_type/:service_name/:file/:target_name", h.RestoreBackup)
+	if !config.Get().DisableRestore {
+		g.POST("/restore/:service_type/:service_name/:file", h.RestoreBackup)
+		g.POST("/restore/:service_type/:service_name/:file/:target_name", h.RestoreBackup)
+	}
 
 	g.GET("/state/:service_type/:service_name", h.GetState)
 }

--- a/router/ui/renderer.go
+++ b/router/ui/renderer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/hako/durafmt"
 	"github.com/labstack/echo/v4"
+	"github.com/swisscom/backman/config"
 	"github.com/swisscom/backman/service/util"
 )
 
@@ -26,6 +27,7 @@ func (h *Handler) RegisterRenderer(e *echo.Echo) {
 		"Duration":    durafmt.Parse,
 		"Bytes":       func(b int64) string { return humanize.Bytes(uint64(b)) },
 		"Time":        humanize.Time,
+		"Config":      config.Get,
 	}
 	renderer := &TemplateRenderer{
 		templates: template.Must(template.New("backman").Funcs(funcMap).ParseGlob("public/*.html")),


### PR DESCRIPTION
Hi,

A small feature to be able to only disable the "restore" feature of backman on web and ui. 

Driver: It is advised by security not to use the same user for creation of backup and restoring the backup. We could introduce two users for this purpose, but its easier to just disable restore function as this is not a frequent operation anyway. This can be temporarily enabled just before restore if needed.

Thanks,
Dipesh